### PR TITLE
PR : SRP 원칙에 맞게 구현체 분리 

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
     Page<Document> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentDomainService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentDomainService.java
@@ -1,0 +1,26 @@
+package com.jinju.jinjuwiki.domain.document.service;
+
+import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import com.jinju.jinjuwiki.global.error.BusinessException;
+import com.jinju.jinjuwiki.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DocumentDomainService {
+
+    private final DocumentRepository documentRepository;
+
+    public Document getDocument(Long id) {
+        return documentRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    public void validateAuthor(Document document, Long authorId) {
+        if (!document.isWrittenBy(authorId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentMapper.java
@@ -1,0 +1,51 @@
+package com.jinju.jinjuwiki.domain.document.service;
+
+import com.jinju.jinjuwiki.domain.document.dto.response.DocumentCreateResponse;
+import com.jinju.jinjuwiki.domain.document.dto.response.DocumentDetailResponse;
+import com.jinju.jinjuwiki.domain.document.dto.response.DocumentSummaryResponse;
+import com.jinju.jinjuwiki.domain.document.entity.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DocumentMapper {
+
+    public DocumentCreateResponse toCreateResponse(Document document) {
+        return new DocumentCreateResponse(
+                document.getId(),
+                document.getTitle(),
+                document.getContent(),
+                document.getCategory().getId(),
+                document.getCategory().getName(),
+                document.getAuthor().getId(),
+                document.getAuthor().getNickname(),
+                document.getCreatedAt()
+        );
+    }
+
+    public DocumentDetailResponse toDetailResponse(Document document) {
+        return new DocumentDetailResponse(
+                document.getId(),
+                document.getTitle(),
+                document.getContent(),
+                document.getCategory().getId(),
+                document.getCategory().getName(),
+                document.getAuthor().getId(),
+                document.getAuthor().getNickname(),
+                document.getViewCount(),
+                document.getCreatedAt(),
+                document.getUpdatedAt()
+        );
+    }
+
+    public DocumentSummaryResponse toSummaryResponse(Document document) {
+        return new DocumentSummaryResponse(
+                document.getId(),
+                document.getTitle(),
+                document.getCategory().getId(),
+                document.getCategory().getName(),
+                document.getAuthor().getNickname(),
+                document.getViewCount(),
+                document.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -29,6 +29,8 @@ public class DocumentServiceImpl implements DocumentService {
     private final DocumentRepository documentRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final DocumentDomainService documentDomainService;
+    private final DocumentMapper documentMapper;
 
     @Override
     @Transactional
@@ -46,17 +48,16 @@ public class DocumentServiceImpl implements DocumentService {
                 .build();
 
         Document savedDocument = documentRepository.save(document);
-        return toCreateResponse(savedDocument);
+        return documentMapper.toCreateResponse(savedDocument);
     }
 
     @Override
     @Transactional
     public DocumentDetailResponse getDocument(Long id) {
-        Document document = documentRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND));
+        Document document = documentDomainService.getDocument(id);
 
         document.increaseViewCount();
-        return toDetailResponse(document);
+        return documentMapper.toDetailResponse(document);
     }
 
     @Override
@@ -66,7 +67,7 @@ public class DocumentServiceImpl implements DocumentService {
                 ? documentRepository.findAllByOrderByCreatedAtDesc(pageable)
                 : documentRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
 
-        return PageResponse.from(documents.map(this::toSummaryResponse));
+        return PageResponse.from(documents.map(documentMapper::toSummaryResponse));
     }
 
     @Override
@@ -82,78 +83,27 @@ public class DocumentServiceImpl implements DocumentService {
                 ? documentRepository.searchByKeyword(normalizedKeyword, pageable)
                 : documentRepository.searchByCategoryAndKeyword(categoryId, normalizedKeyword, pageable);
 
-        return PageResponse.from(documents.map(this::toSummaryResponse));
+        return PageResponse.from(documents.map(documentMapper::toSummaryResponse));
     }
 
     @Override
     @Transactional
     public DocumentDetailResponse updateDocument(Long id, DocumentUpdateRequest request, Long currentUserId) {
-        Document document = getDocumentEntity(id);
-        validateDocumentAuthor(document, currentUserId);
+        Document document = documentDomainService.getDocument(id);
+        documentDomainService.validateAuthor(document, currentUserId);
 
         Category category = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
         document.update(request.title(), request.content(), category);
-        return toDetailResponse(document);
+        return documentMapper.toDetailResponse(document);
     }
 
     @Override
     @Transactional
     public void deleteDocument(Long id, Long currentUserId) {
-        Document document = getDocumentEntity(id);
-        validateDocumentAuthor(document, currentUserId);
+        Document document = documentDomainService.getDocument(id);
+        documentDomainService.validateAuthor(document, currentUserId);
         documentRepository.delete(document);
-    }
-
-    private Document getDocumentEntity(Long id) {
-        return documentRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND));
-    }
-
-    private void validateDocumentAuthor(Document document, Long authorId) {
-        if (!document.isWrittenBy(authorId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
-        }
-    }
-
-    private DocumentCreateResponse toCreateResponse(Document document) {
-        return new DocumentCreateResponse(
-                document.getId(),
-                document.getTitle(),
-                document.getContent(),
-                document.getCategory().getId(),
-                document.getCategory().getName(),
-                document.getAuthor().getId(),
-                document.getAuthor().getNickname(),
-                document.getCreatedAt()
-        );
-    }
-
-    private DocumentDetailResponse toDetailResponse(Document document) {
-        return new DocumentDetailResponse(
-                document.getId(),
-                document.getTitle(),
-                document.getContent(),
-                document.getCategory().getId(),
-                document.getCategory().getName(),
-                document.getAuthor().getId(),
-                document.getAuthor().getNickname(),
-                document.getViewCount(),
-                document.getCreatedAt(),
-                document.getUpdatedAt()
-        );
-    }
-
-    private DocumentSummaryResponse toSummaryResponse(Document document) {
-        return new DocumentSummaryResponse(
-                document.getId(),
-                document.getTitle(),
-                document.getCategory().getId(),
-                document.getCategory().getName(),
-                document.getAuthor().getNickname(),
-                document.getViewCount(),
-                document.getCreatedAt()
-        );
     }
 }


### PR DESCRIPTION
## 작업 내용
- SRP 원칙에 맞게 DocumentService 구현체 분리

## 변경 이유
- 기존 구현체 하나에 너무 많은 책임이 있음

## 관련 이슈
- #23 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
