### PR TITLE
PR : DocumentMapper 패키지 이동

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentMapper.java
@@ -1,4 +1,4 @@
-package com.jinju.jinjuwiki.domain.document.service;
+package com.jinju.jinjuwiki.domain.document.mapper;
 
 import com.jinju.jinjuwiki.domain.document.dto.response.DocumentCreateResponse;
 import com.jinju.jinjuwiki.domain.document.dto.response.DocumentDetailResponse;
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DocumentMapper {
 
+    // 문서 엔티티를 생성 응답 DTO로 변환하는 매퍼다.
     public DocumentCreateResponse toCreateResponse(Document document) {
         return new DocumentCreateResponse(
                 document.getId(),
@@ -22,6 +23,7 @@ public class DocumentMapper {
         );
     }
 
+    // 문서 엔티티를 상세 응답 DTO로 변환하는 매퍼다.
     public DocumentDetailResponse toDetailResponse(Document document) {
         return new DocumentDetailResponse(
                 document.getId(),
@@ -37,6 +39,7 @@ public class DocumentMapper {
         );
     }
 
+    // 문서 엔티티를 목록 응답 DTO로 변환하는 매퍼다.
     public DocumentSummaryResponse toSummaryResponse(Document document) {
         return new DocumentSummaryResponse(
                 document.getId(),

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -8,6 +8,7 @@ import com.jinju.jinjuwiki.domain.document.dto.response.DocumentDetailResponse;
 import com.jinju.jinjuwiki.domain.document.dto.response.DocumentSummaryResponse;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentUpdateRequest;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.document.mapper.DocumentMapper;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;


### PR DESCRIPTION
## 작업 내용
- DocumentMapper 패키지 이동

## 변경 이유
- 해당 클래스는 DTO 변환 로직이 서비스 패키지에 담겨있는 것이 어색해보일 수 있음

## 관련 이슈
- #26 

## 테스트
- [x] `./gradlew test`
- [-] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [-] 리뷰 포인트를 정리했다
