### PR TITLE
PR : private final를 사용하여 상수로 분리

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
@@ -31,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
+    // Authorization 헤더에서 사용하는 JWT 토큰 값
+    private static final String TOKEN_TYPE_BEARER = "Bearer";
+
     private final UserRepository userRepository;
     private final EmailVerificationRepository emailVerificationRepository;
     private final EmailSender emailSender;
@@ -116,7 +119,7 @@ public class AuthServiceImpl implements AuthService {
 
         return new LoginResponse(
                 accessToken,
-                "Bearer",
+                TOKEN_TYPE_BEARER,
                 user.getId(),
                 user.getEmail(),
                 user.getNickname(),

--- a/src/main/java/com/jinju/jinjuwiki/domain/category/entity/CategoryType.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/category/entity/CategoryType.java
@@ -1,0 +1,19 @@
+package com.jinju.jinjuwiki.domain.category.entity;
+
+import lombok.Getter;
+
+// 기본 카테고리 정의 Enum
+@Getter
+public enum CategoryType {
+    SCHOOL("학교"),
+    STUDENT("학생"),
+    INCIDENT("사건사고"),
+    TEACHER("선생님"),
+    ETC("기타");
+
+    private final String displayName;
+
+    CategoryType(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/global/config/CategoryInitializer.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/CategoryInitializer.java
@@ -1,6 +1,7 @@
 package com.jinju.jinjuwiki.global.config;
 
 import com.jinju.jinjuwiki.domain.category.entity.Category;
+import com.jinju.jinjuwiki.domain.category.entity.CategoryType;
 import com.jinju.jinjuwiki.domain.category.repository.CategoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,10 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class CategoryInitializer {
 
-    // 상수화
-    private static final List<String> DEFAULT_CATEGORIES = List.of("학교", "학생", "사건사고", "선생님", "기타");
+    // 기본 카테고리 이름 목록
+    private static final List<String> DEFAULT_CATEGORIES = List.of(CategoryType.values()).stream()
+            .map(CategoryType::getDisplayName)
+            .toList();
 
     private final CategoryRepository categoryRepository;
 

--- a/src/main/java/com/jinju/jinjuwiki/global/config/CategoryInitializer.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/CategoryInitializer.java
@@ -12,13 +12,15 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class CategoryInitializer {
 
+    // 상수화
+    private static final List<String> DEFAULT_CATEGORIES = List.of("학교", "학생", "사건사고", "선생님", "기타");
+
     private final CategoryRepository categoryRepository;
 
     @Bean
     public CommandLineRunner initCategories() {
         return args -> {
-            List<String> defaultCategories = List.of("학교", "학생", "사건사고", "선생님", "기타"); // 카테고리 수정 가능
-            List<Category> categories = defaultCategories.stream()
+            List<Category> categories = DEFAULT_CATEGORIES.stream()
                     .filter(name -> !categoryRepository.existsByName(name))
                     .map(name -> Category.builder().name(name).build())
                     .toList();


### PR DESCRIPTION
## 작업 내용
- 기본 카테고리 문자열 목록을 DEFAULT_CATEGORIES 상수로 분리

## 변경 이유
- 고정형 데이터를 상수로 관리해 의도를 명확하게 표기

## 관련 이슈
- #29 #32 

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
