### PR TITLE
PR : ApiResponse에 message 필드 추가

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
             @Valid @RequestBody EmailVerificationSendRequest request
     ) {
         EmailVerificationSendResponse response = authService.sendVerificationCode(request);
-        return ResponseEntity.ok(ApiResponse.of(response));
+        return ResponseEntity.ok(ApiResponse.of("이메일 인증코드를 발송했습니다.", response));
     }
 
     @PostMapping("/email/verify")
@@ -45,20 +45,20 @@ public class AuthController {
             @Valid @RequestBody EmailVerificationVerifyRequest request
     ) {
         EmailVerificationVerifyResponse response = authService.verifyCode(request);
-        return ResponseEntity.ok(ApiResponse.of(response));
+        return ResponseEntity.ok(ApiResponse.of("이메일 인증이 완료되었습니다.", response));
     }
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입", description = "이메일 인증이 완료된 계정으로 회원가입을 진행합니다.")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
         SignupResponse response = authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of("회원가입이 완료되었습니다.", response));
     }
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT access token을 발급합니다.")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
-        return ResponseEntity.ok(ApiResponse.of(response));
+        return ResponseEntity.ok(ApiResponse.of("로그인에 성공했습니다.", response));
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/controller/DocumentController.java
@@ -53,7 +53,7 @@ public class DocumentController {
     ) {
         Document document = documentService.createDocument(request, userPrincipal.getId());
         DocumentCreateResponse response = DocumentCreateResponseMapper.toResponse(document);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of("문서가 생성되었습니다.", response));
     }
 
     @GetMapping("/{id}")
@@ -104,7 +104,7 @@ public class DocumentController {
     ) {
         Document document = documentService.updateDocument(id, request, userPrincipal.getId());
         DocumentDetailResponse response = DocumentDetailResponseMapper.toResponse(document);
-        return ResponseEntity.ok(ApiResponse.of(response));
+        return ResponseEntity.ok(ApiResponse.of("문서가 수정되었습니다.", response));
     }
 
     @DeleteMapping("/{id}")
@@ -113,11 +113,11 @@ public class DocumentController {
             description = "작성자 본인의 문서를 삭제합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
-    public ResponseEntity<Void> deleteDocument(
+    public ResponseEntity<ApiResponse<Void>> deleteDocument(
             @PathVariable Long id,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         documentService.deleteDocument(id, userPrincipal.getId());
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.success("문서가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/global/response/ApiResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/response/ApiResponse.java
@@ -2,17 +2,45 @@ package com.jinju.jinjuwiki.global.response;
 
 import lombok.Getter;
 
-// 성공시, 응답 규격을 맞추기 위한 DTO
+// 성공/실패 공통 응답 DTO
 @Getter
 public class ApiResponse<T> {
 
+    private final String message;
     private final T data;
 
-    private ApiResponse(T data) {
+    private ApiResponse(String message, T data) {
+        this.message = message;
         this.data = data;
     }
 
+    // 기본 성공 응답 생성 함수
     public static <T> ApiResponse<T> of(T data) {
-        return new ApiResponse<>(data);
+        return success(data);
+    }
+
+    // 메시지 포함 성공 응답 생성 함수
+    public static <T> ApiResponse<T> of(String message, T data) {
+        return success(message, data);
+    }
+
+    // 데이터만 포함한 성공 응답 생성 함수
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(null, data);
+    }
+
+    // 메시지와 데이터를 포함한 성공 응답 생성 함수
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(message, data);
+    }
+
+    // 메시지만 포함한 성공 응답 생성 함수
+    public static ApiResponse<Void> success(String message) {
+        return new ApiResponse<>(message, null);
+    }
+
+    // 메시지만 포함한 실패 응답 생성 함수
+    public static ApiResponse<Void> fail(String message) {
+        return new ApiResponse<>(message, null);
     }
 }


### PR DESCRIPTION
## 작업 내용
- ApiRespons에 message 필드 추가
- of(message, data), success(...), fail(...) 오버로딩 메서드 추가

## 변경 이유
- 성공 응답에서 메시지 유무에 따라 일관된 응답 포맷을 제공하기 위해

## 관련 이슈
- #36  #37

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
