### PR TITLE
PR : validate 책임 분리

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
@@ -36,6 +36,7 @@ public class AuthServiceImpl implements AuthService {
 
     private final UserRepository userRepository;
     private final EmailVerificationRepository emailVerificationRepository;
+    private final AuthValidationService authValidationService;
     private final EmailSender emailSender;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -46,7 +47,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public EmailVerificationSendResponse sendVerificationCode(EmailVerificationSendRequest request) {
-        validateEmailAvailable(request.email());
+        authValidationService.validateEmailAvailable(request.email());
 
         String code = generateVerificationCode();
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(emailVerificationExpirationMinutes);
@@ -89,8 +90,8 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public SignupResponse signup(SignupRequest request) {
-        validateDuplicate(request);
-        validateEmailVerified(request.email());
+        authValidationService.validateDuplicateSignup(request);
+        authValidationService.validateEmailVerified(request.email());
 
         User user = User.builder()
                 .email(request.email())
@@ -125,36 +126,6 @@ public class AuthServiceImpl implements AuthService {
                 user.getNickname(),
                 user.getRole().name()
         );
-    }
-
-    // 중복 확인, 동시성 문제 발견( DB unique 혹은 다른 방법 모색해서 보완 필요 )
-    private void validateDuplicate(SignupRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-        }
-
-        if (userRepository.existsByNickname(request.nickname())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-        }
-    }
-
-    private void validateEmailAvailable(String email) {
-        if (userRepository.existsByEmail(email)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-        }
-    }
-
-    private void validateEmailVerified(String email) {
-        EmailVerification verification = emailVerificationRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED));
-
-        if (verification.isExpired(LocalDateTime.now())) {
-            throw new BusinessException(ErrorCode.EMAIL_VERIFICATION_EXPIRED);
-        }
-
-        if (!verification.isVerified()) {
-            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
-        }
     }
 
     private String generateVerificationCode() {

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthServiceImpl.java
@@ -90,7 +90,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public SignupResponse signup(SignupRequest request) {
-        authValidationService.validateDuplicateSignup(request);
+        authValidationService.validateDuplicateSignup(request.email(), request.nickname());
         authValidationService.validateEmailVerified(request.email());
 
         User user = User.builder()

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthValidationService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthValidationService.java
@@ -1,6 +1,5 @@
 package com.jinju.jinjuwiki.domain.auth.service;
 
-import com.jinju.jinjuwiki.domain.auth.dto.request.SignupRequest;
 import com.jinju.jinjuwiki.domain.auth.entity.EmailVerification;
 import com.jinju.jinjuwiki.domain.auth.repository.EmailVerificationRepository;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
@@ -19,10 +18,10 @@ public class AuthValidationService {
     private final EmailVerificationRepository emailVerificationRepository;
 
     // 회원가입 중복 검증 호출
-    public void validateDuplicateSignup(SignupRequest request) {
-        validateEmailAvailable(request.email());
+    public void validateDuplicateSignup(String email, String nickname) {
+        validateEmailAvailable(email);
 
-        if (userRepository.existsByNickname(request.nickname())) {
+        if (userRepository.existsByNickname(nickname)) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
     }

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthValidationService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/AuthValidationService.java
@@ -1,0 +1,50 @@
+package com.jinju.jinjuwiki.domain.auth.service;
+
+import com.jinju.jinjuwiki.domain.auth.dto.request.SignupRequest;
+import com.jinju.jinjuwiki.domain.auth.entity.EmailVerification;
+import com.jinju.jinjuwiki.domain.auth.repository.EmailVerificationRepository;
+import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
+import com.jinju.jinjuwiki.global.error.BusinessException;
+import com.jinju.jinjuwiki.global.error.ErrorCode;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 인증 관련 사전 검증 전담 서비스
+@Service
+@RequiredArgsConstructor
+public class AuthValidationService {
+
+    private final UserRepository userRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    // 회원가입 중복 검증 호출
+    public void validateDuplicateSignup(SignupRequest request) {
+        validateEmailAvailable(request.email());
+
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
+    // 이메일 중복 검증 호출
+    public void validateEmailAvailable(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    // 이메일 인증 완료 검증 호출
+    public void validateEmailVerified(String email) {
+        EmailVerification verification = emailVerificationRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED));
+
+        if (verification.isExpired(LocalDateTime.now())) {
+            throw new BusinessException(ErrorCode.EMAIL_VERIFICATION_EXPIRED);
+        }
+
+        if (!verification.isVerified()) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- AuthValidationService 클래스 추가
- validateDuplicate, validateEmailAvailable, validateEmailVerified 로직을 검증 서비스로 이동

## 변경 이유
- 인증 서비스에 섞여 있던 검증 책임을 분리해 역할을 명확히 하기 위해

## 관련 이슈
- #31 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
