### PR TITLE
PR : 실제 사용중인 메서드와 경로만 공개로 변경

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/global/config/SecurityConfig.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,6 +24,16 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    // 공개 API 경로 상수
+    private static final String AUTH_EMAIL_SEND_PATH = "/api/auth/email/send";
+    private static final String AUTH_EMAIL_VERIFY_PATH = "/api/auth/email/verify";
+    private static final String AUTH_SIGNUP_PATH = "/api/auth/signup";
+    private static final String AUTH_LOGIN_PATH = "/api/auth/login";
+    private static final String CATEGORY_LIST_PATH = "/api/categories";
+    private static final String DOCUMENT_LIST_PATH = "/api/documents";
+    private static final String DOCUMENT_DETAIL_PATH = "/api/documents/*";
+    private static final String DOCUMENT_SEARCH_PATH = "/api/documents/search";
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -34,14 +45,15 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/categories/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, AUTH_EMAIL_SEND_PATH, AUTH_EMAIL_VERIFY_PATH).permitAll()
+                        .requestMatchers(HttpMethod.POST, AUTH_SIGNUP_PATH, AUTH_LOGIN_PATH).permitAll()
+                        .requestMatchers(HttpMethod.GET, CATEGORY_LIST_PATH).permitAll()
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/error").permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/documents/**").permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.POST, "/api/documents").authenticated()
-                        .requestMatchers(org.springframework.http.HttpMethod.PUT, "/api/documents/**").authenticated()
-                        .requestMatchers(org.springframework.http.HttpMethod.DELETE, "/api/documents/**").authenticated()
+                        .requestMatchers(HttpMethod.GET, DOCUMENT_LIST_PATH, DOCUMENT_SEARCH_PATH, DOCUMENT_DETAIL_PATH).permitAll()
+                        .requestMatchers(HttpMethod.POST, DOCUMENT_LIST_PATH).authenticated()
+                        .requestMatchers(HttpMethod.PUT, DOCUMENT_DETAIL_PATH).authenticated()
+                        .requestMatchers(HttpMethod.DELETE, DOCUMENT_DETAIL_PATH).authenticated()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception


### PR DESCRIPTION
## 작업 내용
- SecurityConfig에 공개 경로 상수 추가
- `/api/auth/**, /api/categories/**, GET /api/documents/**` 같은 넓은 허용 규칙 제거

## 변경 이유
- 리뷰에서 지적한 이상한 경로 허용 문제를 화이트리스트 방식으로 해소하기 위해

## 관련 이슈
- #33 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
