### PR TITLE
PR : JwtFilter에 공개 경로 제외 로직 추가

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/security/JwtAuthenticationFilter.java
@@ -5,21 +5,50 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.http.HttpMethod;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    // JWT 필터 제외 대상 경로 패턴
+    private static final PathPatternParser PATH_PATTERN_PARSER = new PathPatternParser();
+    private static final List<PathPattern> EXCLUDED_PATH_PATTERNS = List.of(
+            PATH_PATTERN_PARSER.parse("/swagger-ui.html"),
+            PATH_PATTERN_PARSER.parse("/swagger-ui/**"),
+            PATH_PATTERN_PARSER.parse("/v3/api-docs/**"),
+            PATH_PATTERN_PARSER.parse("/error")
+    );
+
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String method = request.getMethod();
+
+        if (EXCLUDED_PATH_PATTERNS.stream().anyMatch(pattern -> pattern.matches(PathContainerParser.from(requestUri)))) {
+            return true;
+        }
+
+        if (HttpMethod.POST.matches(method) && isPublicAuthPath(requestUri)) {
+            return true;
+        }
+
+        return HttpMethod.GET.matches(method) && isPublicGetPath(requestUri);
+    }
 
     @Override
     protected void doFilterInternal(
@@ -54,5 +83,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return null;
         }
         return bearerToken.substring(7);
+    }
+
+    // 공개 인증 경로 확인 함수
+    private boolean isPublicAuthPath(String requestUri) {
+        return "/api/auth/email/send".equals(requestUri)
+                || "/api/auth/email/verify".equals(requestUri)
+                || "/api/auth/signup".equals(requestUri)
+                || "/api/auth/login".equals(requestUri);
+    }
+
+    // 공개 조회 경로 확인 함수
+    private boolean isPublicGetPath(String requestUri) {
+        return "/api/categories".equals(requestUri)
+                || "/api/documents".equals(requestUri)
+                || "/api/documents/search".equals(requestUri)
+                || requestUri.startsWith("/api/documents/");
+    }
+
+    // PathPattern 매칭용 PathContainer 변환기
+    private static final class PathContainerParser {
+
+        private PathContainerParser() {
+        }
+
+        private static org.springframework.http.server.PathContainer from(String requestUri) {
+            return org.springframework.http.server.PathContainer.parsePath(requestUri);
+        }
     }
 }


### PR DESCRIPTION
## 작업 내용
- JwtFilter에 공개 경로 제외 로직 추가

## 변경 이유
- 존재하지 않거나 공개된 경로까지 JWT 파싱을 시도하지 않도록 하기 위해

## 관련 이슈
- #38 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
