### PR TITLE
PR : 클라이언트의 요청으로 document 전면 수정

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentCreateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentCreateRequest.java
@@ -1,5 +1,6 @@
 package com.jinju.jinjuwiki.domain.document.dto.request;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -9,10 +10,16 @@ public record DocumentCreateRequest(
         @Size(max = 150, message = "제목은 150자 이하로 입력해야 합니다.")
         String title,
 
-        @NotBlank(message = "본문은 비어 있을 수 없습니다.")
-        String content,
+        @NotBlank(message = "요약은 비어 있을 수 없습니다.")
+        @Size(max = 255, message = "요약은 255자 이하로 입력해야 합니다.")
+        String summary,
 
         @NotNull(message = "카테고리 ID는 필수입니다.")
-        Long categoryId
+        Long categoryId,
+
+        Integer eventYear,
+
+        @NotNull(message = "본문 JSON은 비어 있을 수 없습니다.")
+        JsonNode contentJson
 ) {
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentUpdateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.jinju.jinjuwiki.domain.document.dto.request;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -9,10 +10,16 @@ public record DocumentUpdateRequest(
         @Size(max = 150, message = "제목은 150자 이하로 입력해야 합니다.")
         String title,
 
-        @NotBlank(message = "본문은 비어 있을 수 없습니다.")
-        String content,
+        @NotBlank(message = "요약은 비어 있을 수 없습니다.")
+        @Size(max = 255, message = "요약은 255자 이하로 입력해야 합니다.")
+        String summary,
 
         @NotNull(message = "카테고리 ID는 필수입니다.")
-        Long categoryId
+        Long categoryId,
+
+        Integer eventYear,
+
+        @NotNull(message = "본문 JSON은 비어 있을 수 없습니다.")
+        JsonNode contentJson
 ) {
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentCreateResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentCreateResponse.java
@@ -1,15 +1,18 @@
 package com.jinju.jinjuwiki.domain.document.dto.response;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.LocalDateTime;
 
 public record DocumentCreateResponse(
         Long documentId,
         String title,
-        String content,
+        String summary,
         Long categoryId,
         String categoryName,
+        Integer eventYear,
         Long authorId,
         String authorNickname,
+        JsonNode contentJson,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
@@ -1,15 +1,18 @@
 package com.jinju.jinjuwiki.domain.document.dto.response;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.LocalDateTime;
 
 public record DocumentDetailResponse(
         Long documentId,
         String title,
-        String content,
+        String summary,
         Long categoryId,
         String categoryName,
+        Integer eventYear,
         Long authorId,
         String authorNickname,
+        JsonNode contentJson,
         Long viewCount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentSummaryResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentSummaryResponse.java
@@ -5,8 +5,10 @@ import java.time.LocalDateTime;
 public record DocumentSummaryResponse(
         Long documentId,
         String title,
+        String summary,
         Long categoryId,
         String categoryName,
+        Integer eventYear,
         String authorNickname,
         Long viewCount,
         LocalDateTime createdAt

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
@@ -32,8 +32,17 @@ public class Document extends BaseEntity {
     @Column(nullable = false, length = 150)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String content;
+
+    @Column(length = 255)
+    private String summary;
+
+    @Column
+    private Integer eventYear;
+
+    @Column(columnDefinition = "TEXT")
+    private String contentJson;
 
     @Builder.Default
     @Column(nullable = false)
@@ -54,9 +63,12 @@ public class Document extends BaseEntity {
         this.viewCount++;
     }
 
-    public void update(String title, String content, Category category) {
+    public void update(String title, String content, String summary, Integer eventYear, String contentJson, Category category) {
         this.title = title;
         this.content = content;
+        this.summary = summary;
+        this.eventYear = eventYear;
+        this.contentJson = contentJson;
         this.category = category;
     }
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentCreateResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentCreateResponseMapper.java
@@ -2,6 +2,7 @@ package com.jinju.jinjuwiki.domain.document.mapper;
 
 import com.jinju.jinjuwiki.domain.document.dto.response.DocumentCreateResponse;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 
 public class DocumentCreateResponseMapper {
     private DocumentCreateResponseMapper() {
@@ -12,11 +13,13 @@ public class DocumentCreateResponseMapper {
         return new DocumentCreateResponse(
                 document.getId(),
                 document.getTitle(),
-                document.getContent(),
+                document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getEventYear(),
                 document.getAuthor().getId(),
                 document.getAuthor().getNickname(),
+                DocumentContentJsonCodec.readTree(document.getContentJson() == null ? document.getContent() : document.getContentJson()),
                 document.getCreatedAt()
         );
     }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
@@ -2,6 +2,7 @@ package com.jinju.jinjuwiki.domain.document.mapper;
 
 import com.jinju.jinjuwiki.domain.document.dto.response.DocumentDetailResponse;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 
 public class DocumentDetailResponseMapper {
     private DocumentDetailResponseMapper() {
@@ -12,11 +13,13 @@ public class DocumentDetailResponseMapper {
         return new DocumentDetailResponse(
                 document.getId(),
                 document.getTitle(),
-                document.getContent(),
+                document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getEventYear(),
                 document.getAuthor().getId(),
                 document.getAuthor().getNickname(),
+                DocumentContentJsonCodec.readTree(document.getContentJson() == null ? document.getContent() : document.getContentJson()),
                 document.getViewCount(),
                 document.getCreatedAt(),
                 document.getUpdatedAt()

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentSummaryResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentSummaryResponseMapper.java
@@ -12,8 +12,10 @@ public class DocumentSummaryResponseMapper {
         return new DocumentSummaryResponse(
                 document.getId(),
                 document.getTitle(),
+                document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getEventYear(),
                 document.getAuthor().getNickname(),
                 document.getViewCount(),
                 document.getCreatedAt()

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -20,7 +20,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             select d
             from Document d
             where lower(d.title) like lower(concat('%', :keyword, '%'))
-              or lower(d.content) like lower(concat('%', :keyword, '%'))
+              or lower(d.summary) like lower(concat('%', :keyword, '%'))
             order by d.createdAt desc
             """)
     Page<Document> searchByKeyword(
@@ -34,7 +34,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             where d.category.id = :categoryId
               and (
                   lower(d.title) like lower(concat('%', :keyword, '%'))
-                or lower(d.content) like lower(concat('%', :keyword, '%'))
+                or lower(d.summary) like lower(concat('%', :keyword, '%'))
               )
             order by d.createdAt desc
             """)

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -6,6 +6,7 @@ import com.jinju.jinjuwiki.domain.document.dto.request.DocumentCreateRequest;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentUpdateRequest;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
@@ -36,7 +37,10 @@ public class DocumentServiceImpl implements DocumentService {
 
         Document document = Document.builder()
                 .title(request.title())
-                .content(request.content())
+                .content(DocumentContentJsonCodec.writeValue(request.contentJson()))
+                .summary(request.summary())
+                .eventYear(request.eventYear())
+                .contentJson(DocumentContentJsonCodec.writeValue(request.contentJson()))
                 .author(author)
                 .category(category)
                 .build();
@@ -84,7 +88,14 @@ public class DocumentServiceImpl implements DocumentService {
         Category category = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
-        document.update(request.title(), request.content(), category);
+        document.update(
+                request.title(),
+                DocumentContentJsonCodec.writeValue(request.contentJson()),
+                request.summary(),
+                request.eventYear(),
+                DocumentContentJsonCodec.writeValue(request.contentJson()),
+                category
+        );
         return document;
     }
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/support/DocumentContentJsonCodec.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/support/DocumentContentJsonCodec.java
@@ -1,0 +1,62 @@
+package com.jinju.jinjuwiki.domain.document.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+// 문서 본문 JSON 직렬화 유틸
+public final class DocumentContentJsonCodec {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private DocumentContentJsonCodec() {
+    }
+
+    public static String writeValue(JsonNode contentJson) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(contentJson);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("문서 본문 JSON 직렬화 실패", exception);
+        }
+    }
+
+    public static JsonNode readTree(String contentJson) {
+        try {
+            if (contentJson == null || contentJson.isBlank()) {
+                return createEmptyDocument();
+            }
+            return OBJECT_MAPPER.readTree(contentJson);
+        } catch (JsonProcessingException exception) {
+            return createLegacyDocument(contentJson);
+        }
+    }
+
+    private static JsonNode createEmptyDocument() {
+        ObjectNode documentNode = OBJECT_MAPPER.createObjectNode();
+        documentNode.put("type", "doc");
+        documentNode.putArray("content");
+        return documentNode;
+    }
+
+    private static JsonNode createLegacyDocument(String legacyContent) {
+        if (legacyContent == null || legacyContent.isBlank()) {
+            return createEmptyDocument();
+        }
+
+        ObjectNode documentNode = OBJECT_MAPPER.createObjectNode();
+        documentNode.put("type", "doc");
+
+        ArrayNode contentNodes = documentNode.putArray("content");
+        ObjectNode paragraphNode = contentNodes.addObject();
+        paragraphNode.put("type", "paragraph");
+
+        ArrayNode textNodes = paragraphNode.putArray("content");
+        textNodes.addObject()
+                .put("type", "text")
+                .put("text", legacyContent);
+
+        return documentNode;
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/controller/UserController.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.jinju.jinjuwiki.domain.user.controller;
 
+import com.jinju.jinjuwiki.domain.user.dto.request.UserNicknameUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserPasswordUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.response.UserNicknameUpdateResponse;
 import com.jinju.jinjuwiki.domain.user.dto.response.UserProfileResponse;
 import com.jinju.jinjuwiki.domain.user.service.UserService;
 import com.jinju.jinjuwiki.global.response.ApiResponse;
@@ -7,9 +10,12 @@ import com.jinju.jinjuwiki.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +39,33 @@ public class UserController {
     ) {
         UserProfileResponse response = userService.getProfile(userPrincipal.getId());
         return ResponseEntity.ok(ApiResponse.of(response));
+    }
+
+    @PatchMapping("/me/nickname")
+    @Operation(
+            summary = "내 닉네임 수정",
+            description = "현재 로그인한 사용자의 닉네임을 수정합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<ApiResponse<UserNicknameUpdateResponse>> updateMyNickname(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UserNicknameUpdateRequest request
+    ) {
+        UserNicknameUpdateResponse response = userService.updateNickname(userPrincipal.getId(), request);
+        return ResponseEntity.ok(ApiResponse.of("닉네임이 변경되었습니다.", response));
+    }
+
+    @PatchMapping("/me/password")
+    @Operation(
+            summary = "내 비밀번호 수정",
+            description = "현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<ApiResponse<Void>> updateMyPassword(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UserPasswordUpdateRequest request
+    ) {
+        userService.updatePassword(userPrincipal.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다."));
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/dto/request/UserNicknameUpdateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/dto/request/UserNicknameUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.jinju.jinjuwiki.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserNicknameUpdateRequest(
+        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
+        @Size(max = 30, message = "닉네임은 30자 이하로 입력해야 합니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/dto/request/UserPasswordUpdateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/dto/request/UserPasswordUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.jinju.jinjuwiki.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserPasswordUpdateRequest(
+        @NotBlank(message = "현재 비밀번호는 비어 있을 수 없습니다.")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 비어 있을 수 없습니다.")
+        @Size(min = 8, message = "새 비밀번호는 8자 이상이어야 합니다.")
+        String newPassword
+) {
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/dto/response/UserNicknameUpdateResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/dto/response/UserNicknameUpdateResponse.java
@@ -1,0 +1,7 @@
+package com.jinju.jinjuwiki.domain.user.dto.response;
+
+public record UserNicknameUpdateResponse(
+        Long userId,
+        String nickname
+) {
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/entity/User.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/entity/User.java
@@ -41,4 +41,12 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private UserRole role;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/service/UserService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/service/UserService.java
@@ -1,8 +1,15 @@
 package com.jinju.jinjuwiki.domain.user.service;
 
+import com.jinju.jinjuwiki.domain.user.dto.request.UserNicknameUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserPasswordUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.response.UserNicknameUpdateResponse;
 import com.jinju.jinjuwiki.domain.user.dto.response.UserProfileResponse;
 
 public interface UserService {
 
     UserProfileResponse getProfile(Long userId);
+
+    UserNicknameUpdateResponse updateNickname(Long userId, UserNicknameUpdateRequest request);
+
+    void updatePassword(Long userId, UserPasswordUpdateRequest request);
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/user/service/UserServiceImpl.java
@@ -1,11 +1,15 @@
 package com.jinju.jinjuwiki.domain.user.service;
 
+import com.jinju.jinjuwiki.domain.user.dto.request.UserNicknameUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserPasswordUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.response.UserNicknameUpdateResponse;
 import com.jinju.jinjuwiki.domain.user.dto.response.UserProfileResponse;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserProfileResponse getProfile(Long userId) {
@@ -29,5 +34,39 @@ public class UserServiceImpl implements UserService {
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );
+    }
+
+    @Override
+    @Transactional
+    public UserNicknameUpdateResponse updateNickname(Long userId, UserNicknameUpdateRequest request) {
+        User user = getUser(userId);
+
+        if (!user.getNickname().equals(request.nickname()) && userRepository.existsByNickname(request.nickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.updateNickname(request.nickname());
+        return new UserNicknameUpdateResponse(user.getId(), user.getNickname());
+    }
+
+    @Override
+    @Transactional
+    public void updatePassword(Long userId, UserPasswordUpdateRequest request) {
+        User user = getUser(userId);
+
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.SAME_AS_OLD_PASSWORD);
+        }
+
+        user.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/global/config/SecurityConfig.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                 "https://*.ngrok-free.app",
                 "https://*.ngrok.io"
         ));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization"));
         configuration.setAllowCredentials(false);

--- a/src/main/java/com/jinju/jinjuwiki/global/error/ErrorCode.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/error/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_VERIFICATION_EXPIRED", "인증코드가 만료되었습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_SEND_FAILED", "인증 메일 발송에 실패했습니다."),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "INVALID_LOGIN", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "현재 비밀번호가 올바르지 않습니다."),
+    SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "SAME_AS_OLD_PASSWORD", "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_NOT_FOUND", "카테고리를 찾을 수 없습니다."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DOCUMENT_NOT_FOUND", "문서를 찾을 수 없습니다."),

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -9,12 +9,15 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jinju.jinjuwiki.domain.category.entity.Category;
 import com.jinju.jinjuwiki.domain.category.repository.CategoryRepository;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentCreateRequest;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentUpdateRequest;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.entity.UserRole;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
@@ -37,6 +40,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class DocumentServiceTest {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Mock
     private DocumentRepository documentRepository;
 
@@ -53,15 +58,24 @@ class DocumentServiceTest {
     private DocumentServiceImpl documentService;
 
     @Test
-    @DisplayName("문서를 생성하면 작성자와 카테고리 정보가 함께 반환된다.")
+    @DisplayName("문서를 생성하면 새 스펙 필드가 함께 저장된다.")
     void createDocumentSuccess() {
-        // given
         User author = createUser(1L, "doc1@test.com", "docUser");
         Category category = createCategory(10L, "학교");
-        DocumentCreateRequest request = new DocumentCreateRequest("문서 제목", "문서 본문", 10L);
+        JsonNode contentJson = createContentJson();
+        DocumentCreateRequest request = new DocumentCreateRequest(
+                "문서 제목",
+                "문서 요약",
+                10L,
+                2024,
+                contentJson
+        );
         Document savedDocument = Document.builder()
                 .title("문서 제목")
-                .content("문서 본문")
+                .content(DocumentContentJsonCodec.writeValue(contentJson))
+                .summary("문서 요약")
+                .eventYear(2024)
+                .contentJson(DocumentContentJsonCodec.writeValue(contentJson))
                 .author(author)
                 .category(category)
                 .build();
@@ -70,13 +84,13 @@ class DocumentServiceTest {
         when(categoryRepository.findById(10L)).thenReturn(Optional.of(category));
         when(documentRepository.save(any(Document.class))).thenReturn(savedDocument);
 
-        // when
         Document response = documentService.createDocument(request, 1L);
 
-        // then
         assertThat(response.getId()).isEqualTo(100L);
+        assertThat(response.getSummary()).isEqualTo("문서 요약");
+        assertThat(response.getEventYear()).isEqualTo(2024);
+        assertThat(DocumentContentJsonCodec.readTree(response.getContentJson())).isEqualTo(contentJson);
         assertThat(response.getAuthor().getNickname()).isEqualTo("docUser");
-        assertThat(response.getCategory().getName()).isEqualTo("학교");
         verify(userRepository).findById(1L);
         verify(categoryRepository).findById(10L);
         verify(documentRepository).save(any(Document.class));
@@ -85,17 +99,20 @@ class DocumentServiceTest {
     @Test
     @DisplayName("존재하지 않는 작성자 ID로 문서를 생성하면 예외가 발생한다.")
     void createDocumentFailWhenUserNotFound() {
-        // given
-        DocumentCreateRequest request = new DocumentCreateRequest("문서 제목", "문서 본문", 10L);
+        DocumentCreateRequest request = new DocumentCreateRequest(
+                "문서 제목",
+                "문서 요약",
+                10L,
+                2024,
+                createContentJson()
+        );
         when(userRepository.findById(999L)).thenReturn(Optional.empty());
 
-        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.createDocument(request, 999L)
         );
 
-        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
         verify(userRepository).findById(999L);
     }
@@ -103,10 +120,12 @@ class DocumentServiceTest {
     @Test
     @DisplayName("문서를 조회하면 조회수가 증가한다.")
     void getDocumentSuccess() {
-        // given
         Document document = Document.builder()
                 .title("수학 공부법")
-                .content("개념부터 반복")
+                .content(DocumentContentJsonCodec.writeValue(createContentJson()))
+                .summary("시험 대비 요약")
+                .eventYear(2024)
+                .contentJson(DocumentContentJsonCodec.writeValue(createContentJson()))
                 .author(createUser(2L, "doc2@test.com", "docUser2"))
                 .category(createCategory(20L, "학생"))
                 .build();
@@ -114,10 +133,8 @@ class DocumentServiceTest {
 
         when(documentDomainService.getDocument(200L)).thenReturn(document);
 
-        // when
         Document response = documentService.getDocument(200L);
 
-        // then
         assertThat(response.getId()).isEqualTo(200L);
         assertThat(response.getViewCount()).isEqualTo(1L);
         verify(documentDomainService).getDocument(200L);
@@ -126,18 +143,19 @@ class DocumentServiceTest {
     @Test
     @DisplayName("문서 목록은 최신순으로 페이지 조회할 수 있다.")
     void getDocumentsSuccess() {
-        // given
         Document older = createDocument(
                 301L,
                 "첫 번째 글",
-                "내용 1",
+                "요약 1",
+                2023,
                 createUser(3L, "doc3@test.com", "docUser3"),
                 createCategory(30L, "사건사고")
         );
         Document newer = createDocument(
                 302L,
                 "두 번째 글",
-                "내용 2",
+                "요약 2",
+                2024,
                 createUser(3L, "doc3@test.com", "docUser3"),
                 createCategory(30L, "사건사고")
         );
@@ -146,10 +164,8 @@ class DocumentServiceTest {
         when(documentRepository.findByCategoryIdOrderByCreatedAtDesc(eq(30L), any(Pageable.class)))
                 .thenReturn(pageResponse);
 
-        // when
         Page<Document> response = documentService.getDocuments(30L, 0, 10);
 
-        // then
         assertThat(response.getContent()).hasSize(2);
         assertThat(response.getContent().get(0).getTitle()).isEqualTo("두 번째 글");
         verify(documentRepository).findByCategoryIdOrderByCreatedAtDesc(eq(30L), any(Pageable.class));
@@ -158,25 +174,25 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자는 자신의 문서를 수정할 수 있다.")
     void updateDocumentSuccess() {
-        // given
         User author = createUser(4L, "doc4@test.com", "docUser4");
         Category category = createCategory(40L, "학교");
         Category updatedCategory = createCategory(41L, "선생님");
-        Document document = createDocument(400L, "원래 제목", "원래 본문", author, category);
+        Document document = createDocument(400L, "원래 제목", "원래 요약", 2023, author, category);
+        JsonNode updatedContentJson = createContentJson();
         when(documentDomainService.getDocument(400L)).thenReturn(document);
         doNothing().when(documentDomainService).validateAuthor(document, 4L);
         when(categoryRepository.findById(41L)).thenReturn(Optional.of(updatedCategory));
 
-        // when
         Document response = documentService.updateDocument(
                 400L,
-                new DocumentUpdateRequest("수정 제목", "수정 본문", 41L),
+                new DocumentUpdateRequest("수정 제목", "수정 요약", 41L, 2024, updatedContentJson),
                 4L
         );
 
-        // then
         assertThat(response.getTitle()).isEqualTo("수정 제목");
-        assertThat(response.getContent()).isEqualTo("수정 본문");
+        assertThat(response.getSummary()).isEqualTo("수정 요약");
+        assertThat(response.getEventYear()).isEqualTo(2024);
+        assertThat(DocumentContentJsonCodec.readTree(response.getContentJson())).isEqualTo(updatedContentJson);
         assertThat(response.getCategory().getName()).isEqualTo("선생님");
         verify(documentDomainService).getDocument(400L);
         verify(documentDomainService).validateAuthor(document, 4L);
@@ -186,11 +202,11 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자가 아니면 문서를 수정할 수 없다.")
     void updateDocumentFailWhenNotAuthor() {
-        // given
         Document document = createDocument(
                 500L,
                 "제목",
-                "본문",
+                "요약",
+                2024,
                 createUser(5L, "doc5@test.com", "author5"),
                 createCategory(50L, "학교")
         );
@@ -199,17 +215,15 @@ class DocumentServiceTest {
                 .when(documentDomainService)
                 .validateAuthor(document, 6L);
 
-        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.updateDocument(
                         500L,
-                        new DocumentUpdateRequest("수정 제목", "수정 본문", 50L),
+                        new DocumentUpdateRequest("수정 제목", "수정 요약", 50L, 2024, createContentJson()),
                         6L
                 )
         );
 
-        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
         verify(documentDomainService).getDocument(500L);
         verify(documentDomainService).validateAuthor(document, 6L);
@@ -218,21 +232,19 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자는 자신의 문서를 삭제할 수 있다.")
     void deleteDocumentSuccess() {
-        // given
         Document document = createDocument(
                 700L,
                 "삭제 제목",
-                "삭제 본문",
+                "삭제 요약",
+                2024,
                 createUser(7L, "doc7@test.com", "docUser7"),
                 createCategory(70L, "기타")
         );
         when(documentDomainService.getDocument(700L)).thenReturn(document);
         doNothing().when(documentDomainService).validateAuthor(document, 7L);
 
-        // when
         documentService.deleteDocument(700L, 7L);
 
-        // then
         verify(documentDomainService).getDocument(700L);
         verify(documentDomainService).validateAuthor(document, 7L);
         verify(documentRepository).delete(document);
@@ -241,11 +253,11 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자가 아니면 문서를 삭제할 수 없다.")
     void deleteDocumentFailWhenNotAuthor() {
-        // given
         Document document = createDocument(
                 800L,
                 "삭제 전 제목",
-                "삭제 전 본문",
+                "삭제 전 요약",
+                2024,
                 createUser(8L, "doc8@test.com", "author8"),
                 createCategory(80L, "학교")
         );
@@ -254,36 +266,32 @@ class DocumentServiceTest {
                 .when(documentDomainService)
                 .validateAuthor(document, 9L);
 
-        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.deleteDocument(800L, 9L)
         );
 
-        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
         verify(documentDomainService).getDocument(800L);
         verify(documentDomainService).validateAuthor(document, 9L);
     }
 
     @Test
-    @DisplayName("키워드로 제목과 본문을 검색할 수 있다.")
+    @DisplayName("키워드로 제목과 요약을 검색할 수 있다.")
     void searchDocumentsSuccess() {
-        // given
         Document document = createDocument(
                 1000L,
                 "수학 공부법",
                 "시험 대비 공부 루틴",
+                2024,
                 createUser(10L, "doc10@test.com", "docUser10"),
                 createCategory(100L, "학생")
         );
         Page<Document> searchResult = new PageImpl<>(List.of(document));
         when(documentRepository.searchByKeyword(eq("공부"), any(Pageable.class))).thenReturn(searchResult);
 
-        // when
         Page<Document> response = documentService.searchDocuments("공부", null, 0, 10);
 
-        // then
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getTitle()).isEqualTo("수학 공부법");
         verify(documentRepository).searchByKeyword(eq("공부"), any(Pageable.class));
@@ -292,11 +300,11 @@ class DocumentServiceTest {
     @Test
     @DisplayName("검색은 카테고리 필터와 함께 사용할 수 있다.")
     void searchDocumentsWithCategory() {
-        // given
         Document document = createDocument(
                 1100L,
                 "수학 시험 대비",
                 "공부 계획",
+                2024,
                 createUser(11L, "doc11@test.com", "docUser11"),
                 createCategory(110L, "학생")
         );
@@ -304,10 +312,8 @@ class DocumentServiceTest {
         when(documentRepository.searchByCategoryAndKeyword(eq(110L), eq("시험"), any(Pageable.class)))
                 .thenReturn(searchResult);
 
-        // when
         Page<Document> response = documentService.searchDocuments("시험", 110L, 0, 10);
 
-        // then
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getCategory().getName()).isEqualTo("학생");
         verify(documentRepository).searchByCategoryAndKeyword(eq(110L), eq("시험"), any(Pageable.class));
@@ -316,17 +322,21 @@ class DocumentServiceTest {
     @Test
     @DisplayName("빈 검색어로 검색하면 예외가 발생한다.")
     void searchDocumentsFailWhenKeywordIsBlank() {
-        // given
         String keyword = "   ";
 
-        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.searchDocuments(keyword, null, 0, 10)
         );
 
-        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    private JsonNode createContentJson() {
+        var documentNode = OBJECT_MAPPER.createObjectNode();
+        documentNode.put("type", "doc");
+        documentNode.putArray("content");
+        return documentNode;
     }
 
     // 테스트용 사용자 생성 함수
@@ -351,10 +361,13 @@ class DocumentServiceTest {
     }
 
     // 테스트용 문서 생성 함수
-    private Document createDocument(Long id, String title, String content, User author, Category category) {
+    private Document createDocument(Long id, String title, String summary, Integer eventYear, User author, Category category) {
         Document document = Document.builder()
                 .title(title)
-                .content(content)
+                .content(DocumentContentJsonCodec.writeValue(createContentJson()))
+                .summary(summary)
+                .eventYear(eventYear)
+                .contentJson(DocumentContentJsonCodec.writeValue(createContentJson()))
                 .author(author)
                 .category(category)
                 .build();

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -60,6 +60,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("문서를 생성하면 새 스펙 필드가 함께 저장된다.")
     void createDocumentSuccess() {
+        // given
         User author = createUser(1L, "doc1@test.com", "docUser");
         Category category = createCategory(10L, "학교");
         JsonNode contentJson = createContentJson();
@@ -84,8 +85,10 @@ class DocumentServiceTest {
         when(categoryRepository.findById(10L)).thenReturn(Optional.of(category));
         when(documentRepository.save(any(Document.class))).thenReturn(savedDocument);
 
+        // when
         Document response = documentService.createDocument(request, 1L);
 
+        // then
         assertThat(response.getId()).isEqualTo(100L);
         assertThat(response.getSummary()).isEqualTo("문서 요약");
         assertThat(response.getEventYear()).isEqualTo(2024);
@@ -99,6 +102,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("존재하지 않는 작성자 ID로 문서를 생성하면 예외가 발생한다.")
     void createDocumentFailWhenUserNotFound() {
+        // given
         DocumentCreateRequest request = new DocumentCreateRequest(
                 "문서 제목",
                 "문서 요약",
@@ -108,11 +112,13 @@ class DocumentServiceTest {
         );
         when(userRepository.findById(999L)).thenReturn(Optional.empty());
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.createDocument(request, 999L)
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
         verify(userRepository).findById(999L);
     }
@@ -120,6 +126,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("문서를 조회하면 조회수가 증가한다.")
     void getDocumentSuccess() {
+        // given
         Document document = Document.builder()
                 .title("수학 공부법")
                 .content(DocumentContentJsonCodec.writeValue(createContentJson()))
@@ -133,8 +140,10 @@ class DocumentServiceTest {
 
         when(documentDomainService.getDocument(200L)).thenReturn(document);
 
+        // when
         Document response = documentService.getDocument(200L);
 
+        // then
         assertThat(response.getId()).isEqualTo(200L);
         assertThat(response.getViewCount()).isEqualTo(1L);
         verify(documentDomainService).getDocument(200L);
@@ -143,6 +152,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("문서 목록은 최신순으로 페이지 조회할 수 있다.")
     void getDocumentsSuccess() {
+        // given
         Document older = createDocument(
                 301L,
                 "첫 번째 글",
@@ -164,8 +174,10 @@ class DocumentServiceTest {
         when(documentRepository.findByCategoryIdOrderByCreatedAtDesc(eq(30L), any(Pageable.class)))
                 .thenReturn(pageResponse);
 
+        // when
         Page<Document> response = documentService.getDocuments(30L, 0, 10);
 
+        // then
         assertThat(response.getContent()).hasSize(2);
         assertThat(response.getContent().get(0).getTitle()).isEqualTo("두 번째 글");
         verify(documentRepository).findByCategoryIdOrderByCreatedAtDesc(eq(30L), any(Pageable.class));
@@ -174,6 +186,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자는 자신의 문서를 수정할 수 있다.")
     void updateDocumentSuccess() {
+        // given
         User author = createUser(4L, "doc4@test.com", "docUser4");
         Category category = createCategory(40L, "학교");
         Category updatedCategory = createCategory(41L, "선생님");
@@ -183,12 +196,14 @@ class DocumentServiceTest {
         doNothing().when(documentDomainService).validateAuthor(document, 4L);
         when(categoryRepository.findById(41L)).thenReturn(Optional.of(updatedCategory));
 
+        // when
         Document response = documentService.updateDocument(
                 400L,
                 new DocumentUpdateRequest("수정 제목", "수정 요약", 41L, 2024, updatedContentJson),
                 4L
         );
 
+        // then
         assertThat(response.getTitle()).isEqualTo("수정 제목");
         assertThat(response.getSummary()).isEqualTo("수정 요약");
         assertThat(response.getEventYear()).isEqualTo(2024);
@@ -202,6 +217,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자가 아니면 문서를 수정할 수 없다.")
     void updateDocumentFailWhenNotAuthor() {
+        // given
         Document document = createDocument(
                 500L,
                 "제목",
@@ -215,6 +231,7 @@ class DocumentServiceTest {
                 .when(documentDomainService)
                 .validateAuthor(document, 6L);
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.updateDocument(
@@ -224,6 +241,7 @@ class DocumentServiceTest {
                 )
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
         verify(documentDomainService).getDocument(500L);
         verify(documentDomainService).validateAuthor(document, 6L);
@@ -232,6 +250,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자는 자신의 문서를 삭제할 수 있다.")
     void deleteDocumentSuccess() {
+        // given
         Document document = createDocument(
                 700L,
                 "삭제 제목",
@@ -243,8 +262,10 @@ class DocumentServiceTest {
         when(documentDomainService.getDocument(700L)).thenReturn(document);
         doNothing().when(documentDomainService).validateAuthor(document, 7L);
 
+        // when
         documentService.deleteDocument(700L, 7L);
 
+        // then
         verify(documentDomainService).getDocument(700L);
         verify(documentDomainService).validateAuthor(document, 7L);
         verify(documentRepository).delete(document);
@@ -253,6 +274,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("작성자가 아니면 문서를 삭제할 수 없다.")
     void deleteDocumentFailWhenNotAuthor() {
+        // given
         Document document = createDocument(
                 800L,
                 "삭제 전 제목",
@@ -266,11 +288,13 @@ class DocumentServiceTest {
                 .when(documentDomainService)
                 .validateAuthor(document, 9L);
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.deleteDocument(800L, 9L)
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_DOCUMENT_ACCESS);
         verify(documentDomainService).getDocument(800L);
         verify(documentDomainService).validateAuthor(document, 9L);
@@ -279,6 +303,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("키워드로 제목과 요약을 검색할 수 있다.")
     void searchDocumentsSuccess() {
+        // given
         Document document = createDocument(
                 1000L,
                 "수학 공부법",
@@ -290,8 +315,10 @@ class DocumentServiceTest {
         Page<Document> searchResult = new PageImpl<>(List.of(document));
         when(documentRepository.searchByKeyword(eq("공부"), any(Pageable.class))).thenReturn(searchResult);
 
+        // when
         Page<Document> response = documentService.searchDocuments("공부", null, 0, 10);
 
+        // then
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getTitle()).isEqualTo("수학 공부법");
         verify(documentRepository).searchByKeyword(eq("공부"), any(Pageable.class));
@@ -300,6 +327,7 @@ class DocumentServiceTest {
     @Test
     @DisplayName("검색은 카테고리 필터와 함께 사용할 수 있다.")
     void searchDocumentsWithCategory() {
+        // given
         Document document = createDocument(
                 1100L,
                 "수학 시험 대비",
@@ -312,8 +340,10 @@ class DocumentServiceTest {
         when(documentRepository.searchByCategoryAndKeyword(eq(110L), eq("시험"), any(Pageable.class)))
                 .thenReturn(searchResult);
 
+        // when
         Page<Document> response = documentService.searchDocuments("시험", 110L, 0, 10);
 
+        // then
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getCategory().getName()).isEqualTo("학생");
         verify(documentRepository).searchByCategoryAndKeyword(eq(110L), eq("시험"), any(Pageable.class));
@@ -322,20 +352,24 @@ class DocumentServiceTest {
     @Test
     @DisplayName("빈 검색어로 검색하면 예외가 발생한다.")
     void searchDocumentsFailWhenKeywordIsBlank() {
+        // given
         String keyword = "   ";
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> documentService.searchDocuments(keyword, null, 0, 10)
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT);
     }
 
     private JsonNode createContentJson() {
-        var documentNode = OBJECT_MAPPER.createObjectNode();
-        documentNode.put("type", "doc");
-        documentNode.putArray("content");
+        // 테스트용 본문 JSON 생성 함수
+        JsonNode documentNode = OBJECT_MAPPER.createObjectNode();
+        ((com.fasterxml.jackson.databind.node.ObjectNode) documentNode).put("type", "doc");
+        ((com.fasterxml.jackson.databind.node.ObjectNode) documentNode).putArray("content");
         return documentNode;
     }
 

--- a/src/test/java/com/jinju/jinjuwiki/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/user/controller/UserControllerTest.java
@@ -100,10 +100,12 @@ class UserControllerTest {
     @Test
     @DisplayName("로그인한 사용자는 자신의 닉네임을 수정할 수 있다.")
     void updateMyNicknameSuccess() throws Exception {
+        // given
         UserNicknameUpdateRequest request = new UserNicknameUpdateRequest("updatedUser");
         UserNicknameUpdateResponse response = new UserNicknameUpdateResponse(1L, "updatedUser");
         when(userService.updateNickname(1L, request)).thenReturn(response);
 
+        // when
         ResultActions result = mockMvc.perform(
                 patch("/api/users/me/nickname")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
@@ -111,6 +113,7 @@ class UserControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request))
         );
 
+        // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("닉네임이 변경되었습니다."))
                 .andExpect(jsonPath("$.data.userId").value(1L))
@@ -122,8 +125,10 @@ class UserControllerTest {
     @Test
     @DisplayName("로그인한 사용자는 자신의 비밀번호를 수정할 수 있다.")
     void updateMyPasswordSuccess() throws Exception {
+        // given
         UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "new-password1");
 
+        // when
         ResultActions result = mockMvc.perform(
                 patch("/api/users/me/password")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
@@ -131,6 +136,7 @@ class UserControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request))
         );
 
+        // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("비밀번호가 변경되었습니다."))
                 .andExpect(jsonPath("$.data").isEmpty());

--- a/src/test/java/com/jinju/jinjuwiki/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/user/controller/UserControllerTest.java
@@ -2,10 +2,15 @@ package com.jinju.jinjuwiki.domain.user.controller;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserNicknameUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserPasswordUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.response.UserNicknameUpdateResponse;
 import com.jinju.jinjuwiki.domain.user.dto.response.UserProfileResponse;
 import com.jinju.jinjuwiki.domain.user.service.UserService;
 import com.jinju.jinjuwiki.global.security.UserPrincipal;
@@ -34,6 +39,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 // 사용자 컨트롤러 MockMvc 단위 테스트 클래스
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Mock
     private UserService userService;
@@ -88,6 +95,47 @@ class UserControllerTest {
 
         // then
         result.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자는 자신의 닉네임을 수정할 수 있다.")
+    void updateMyNicknameSuccess() throws Exception {
+        UserNicknameUpdateRequest request = new UserNicknameUpdateRequest("updatedUser");
+        UserNicknameUpdateResponse response = new UserNicknameUpdateResponse(1L, "updatedUser");
+        when(userService.updateNickname(1L, request)).thenReturn(response);
+
+        ResultActions result = mockMvc.perform(
+                patch("/api/users/me/nickname")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
+                        .contentType("application/json")
+                        .content(OBJECT_MAPPER.writeValueAsString(request))
+        );
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("닉네임이 변경되었습니다."))
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.nickname").value("updatedUser"));
+
+        verify(userService).updateNickname(1L, request);
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자는 자신의 비밀번호를 수정할 수 있다.")
+    void updateMyPasswordSuccess() throws Exception {
+        UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "new-password1");
+
+        ResultActions result = mockMvc.perform(
+                patch("/api/users/me/password")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
+                        .contentType("application/json")
+                        .content(OBJECT_MAPPER.writeValueAsString(request))
+        );
+
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호가 변경되었습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(userService).updatePassword(1L, request);
     }
 
     // 테스트용 인증 필터 클래스

--- a/src/test/java/com/jinju/jinjuwiki/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/user/service/UserServiceTest.java
@@ -40,12 +40,15 @@ class UserServiceTest {
     @Test
     @DisplayName("사용자는 자신의 닉네임을 변경할 수 있다.")
     void updateNicknameSuccess() {
+        // given
         User user = createUser(1L, "user@test.com", "oldNick", "encoded-password");
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("newNick")).thenReturn(false);
 
+        // when
         UserNicknameUpdateResponse response = userService.updateNickname(1L, new UserNicknameUpdateRequest("newNick"));
 
+        // then
         assertThat(response.userId()).isEqualTo(1L);
         assertThat(response.nickname()).isEqualTo("newNick");
         assertThat(user.getNickname()).isEqualTo("newNick");
@@ -55,21 +58,25 @@ class UserServiceTest {
     @Test
     @DisplayName("이미 사용 중인 닉네임으로 변경하면 예외가 발생한다.")
     void updateNicknameFailWhenDuplicate() {
+        // given
         User user = createUser(1L, "user@test.com", "oldNick", "encoded-password");
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("newNick")).thenReturn(true);
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> userService.updateNickname(1L, new UserNicknameUpdateRequest("newNick"))
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
     }
 
     @Test
     @DisplayName("사용자는 현재 비밀번호 확인 후 새 비밀번호로 변경할 수 있다.")
     void updatePasswordSuccess() {
+        // given
         User user = createUser(1L, "user@test.com", "nick", "encoded-password");
         UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "new-password");
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
@@ -77,8 +84,10 @@ class UserServiceTest {
         when(passwordEncoder.matches("new-password", "encoded-password")).thenReturn(false);
         when(passwordEncoder.encode("new-password")).thenReturn("encoded-new-password");
 
+        // when
         userService.updatePassword(1L, request);
 
+        // then
         assertThat(user.getPassword()).isEqualTo("encoded-new-password");
         verify(passwordEncoder).encode("new-password");
     }
@@ -86,16 +95,19 @@ class UserServiceTest {
     @Test
     @DisplayName("현재 비밀번호가 다르면 변경할 수 없다.")
     void updatePasswordFailWhenCurrentPasswordMismatch() {
+        // given
         User user = createUser(1L, "user@test.com", "nick", "encoded-password");
         UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("wrong-password", "new-password");
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("wrong-password", "encoded-password")).thenReturn(false);
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> userService.updatePassword(1L, request)
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PASSWORD);
         verify(passwordEncoder, never()).encode("new-password");
     }
@@ -103,21 +115,25 @@ class UserServiceTest {
     @Test
     @DisplayName("새 비밀번호가 현재 비밀번호와 같으면 변경할 수 없다.")
     void updatePasswordFailWhenSameAsOldPassword() {
+        // given
         User user = createUser(1L, "user@test.com", "nick", "encoded-password");
         UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "old-password");
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("old-password", "encoded-password")).thenReturn(true);
         when(passwordEncoder.matches("old-password", "encoded-password")).thenReturn(true);
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> userService.updatePassword(1L, request)
         );
 
+        // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SAME_AS_OLD_PASSWORD);
         verify(passwordEncoder, never()).encode("old-password");
     }
 
+    // 테스트용 사용자 생성 함수
     private User createUser(Long id, String email, String nickname, String password) {
         User user = User.builder()
                 .email(email)

--- a/src/test/java/com/jinju/jinjuwiki/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/user/service/UserServiceTest.java
@@ -1,0 +1,131 @@
+package com.jinju.jinjuwiki.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jinju.jinjuwiki.domain.user.dto.request.UserNicknameUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.request.UserPasswordUpdateRequest;
+import com.jinju.jinjuwiki.domain.user.dto.response.UserNicknameUpdateResponse;
+import com.jinju.jinjuwiki.domain.user.entity.User;
+import com.jinju.jinjuwiki.domain.user.entity.UserRole;
+import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
+import com.jinju.jinjuwiki.global.error.BusinessException;
+import com.jinju.jinjuwiki.global.error.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+// 사용자 서비스 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("사용자는 자신의 닉네임을 변경할 수 있다.")
+    void updateNicknameSuccess() {
+        User user = createUser(1L, "user@test.com", "oldNick", "encoded-password");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("newNick")).thenReturn(false);
+
+        UserNicknameUpdateResponse response = userService.updateNickname(1L, new UserNicknameUpdateRequest("newNick"));
+
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("newNick");
+        assertThat(user.getNickname()).isEqualTo("newNick");
+        verify(userRepository).existsByNickname("newNick");
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임으로 변경하면 예외가 발생한다.")
+    void updateNicknameFailWhenDuplicate() {
+        User user = createUser(1L, "user@test.com", "oldNick", "encoded-password");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("newNick")).thenReturn(true);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userService.updateNickname(1L, new UserNicknameUpdateRequest("newNick"))
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("사용자는 현재 비밀번호 확인 후 새 비밀번호로 변경할 수 있다.")
+    void updatePasswordSuccess() {
+        User user = createUser(1L, "user@test.com", "nick", "encoded-password");
+        UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "new-password");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("old-password", "encoded-password")).thenReturn(true);
+        when(passwordEncoder.matches("new-password", "encoded-password")).thenReturn(false);
+        when(passwordEncoder.encode("new-password")).thenReturn("encoded-new-password");
+
+        userService.updatePassword(1L, request);
+
+        assertThat(user.getPassword()).isEqualTo("encoded-new-password");
+        verify(passwordEncoder).encode("new-password");
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 다르면 변경할 수 없다.")
+    void updatePasswordFailWhenCurrentPasswordMismatch() {
+        User user = createUser(1L, "user@test.com", "nick", "encoded-password");
+        UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("wrong-password", "new-password");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong-password", "encoded-password")).thenReturn(false);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userService.updatePassword(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_PASSWORD);
+        verify(passwordEncoder, never()).encode("new-password");
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 현재 비밀번호와 같으면 변경할 수 없다.")
+    void updatePasswordFailWhenSameAsOldPassword() {
+        User user = createUser(1L, "user@test.com", "nick", "encoded-password");
+        UserPasswordUpdateRequest request = new UserPasswordUpdateRequest("old-password", "old-password");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("old-password", "encoded-password")).thenReturn(true);
+        when(passwordEncoder.matches("old-password", "encoded-password")).thenReturn(true);
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userService.updatePassword(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SAME_AS_OLD_PASSWORD);
+        verify(passwordEncoder, never()).encode("old-password");
+    }
+
+    private User createUser(Long id, String email, String nickname, String password) {
+        User user = User.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 문서 API 요청/응답 DTO를 summary, eventYear, contentJson 기준으로 변경
- 문서 엔티티, 매퍼, 서비스, 검색 리포지토리를 새 스펙에 맞게 반영
- PATCH /api/users/me/nickname, PATCH /api/users/me/password 추가

## 변경 이유
- 프론트가 요청한 1단계 범위의 문서 스펙 변경과 사용자 정보 수정 API를 단계별로 안전하게 반영하기 위해

## 관련 이슈
- 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
