### PR TITLE
refactor : Redis 기반 조회수 집계 구조 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/jinju/jinjuwiki/JinjuWikiApplication.java
+++ b/src/main/java/com/jinju/jinjuwiki/JinjuWikiApplication.java
@@ -2,12 +2,15 @@ package com.jinju.jinjuwiki;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+// 애플리케이션 부트스트랩 및 스케줄링 활성화 클래스
 @SpringBootApplication
+@EnableScheduling
 public class JinjuWikiApplication {
 
+    // 애플리케이션 실행 메서드
     public static void main(String[] args) {
         SpringApplication.run(JinjuWikiApplication.class, args);
     }
-
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -4,6 +4,7 @@ import com.jinju.jinjuwiki.domain.document.entity.Document;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,6 +15,15 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     Page<Document> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<Document> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
+
+    // 조회수 원자 증가 쿼리
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Document d
+            set d.viewCount = d.viewCount + 1
+            where d.id = :documentId
+            """)
+    int incrementViewCount(@Param("documentId") Long documentId);
 
     // concat() : 두개 이상의 컬럼이나 문자열을 순서대로 묶어 하나의 문자열로 반환
     @Query("""

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -25,6 +25,15 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             """)
     int incrementViewCount(@Param("documentId") Long documentId);
 
+    // 조회수 delta 원자 증가 쿼리
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            update Document d
+            set d.viewCount = d.viewCount + :delta
+            where d.id = :documentId
+            """)
+    int incrementViewCountBy(@Param("documentId") Long documentId, @Param("delta") long delta);
+
     // concat() : 두개 이상의 컬럼이나 문자열을 순서대로 묶어 하나의 문자열로 반환
     @Query("""
             select d

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -17,7 +17,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     Page<Document> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 
     // 조회수 원자 증가 쿼리
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("""
             update Document d
             set d.viewCount = d.viewCount + 1

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -8,11 +8,11 @@ import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 import com.jinju.jinjuwiki.domain.search.service.DocumentViewLogService;
+import com.jinju.jinjuwiki.domain.search.service.RedisDocumentViewCountBuffer;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,7 +29,7 @@ public class DocumentServiceImpl implements DocumentService {
     private final CategoryRepository categoryRepository;
     private final DocumentDomainService documentDomainService;
     private final DocumentViewLogService documentViewLogService;
-    private final EntityManager entityManager;
+    private final RedisDocumentViewCountBuffer redisDocumentViewCountBuffer;
 
     @Override
     @Transactional
@@ -58,7 +58,7 @@ public class DocumentServiceImpl implements DocumentService {
         Document document = documentDomainService.getDocument(id);
 
         if (recordDocumentView(document, viewerUserId, viewerIp)) {
-            refreshDocumentViewCount(document);
+            bufferDocumentViewCount(document);
         }
         return document;
     }
@@ -136,11 +136,9 @@ public class DocumentServiceImpl implements DocumentService {
         return documentViewLogService.save(document, null, viewerIp);
     }
 
-    // 조회수 원자 증가 반영 메서드
-    private void refreshDocumentViewCount(Document document) {
-        int updatedCount = documentRepository.incrementViewCount(document.getId());
-        if (updatedCount > 0) {
-            entityManager.refresh(document);
-        }
+    // 조회수 Redis 누적 반영 메서드
+    private void bufferDocumentViewCount(Document document) {
+        redisDocumentViewCountBuffer.increment(document.getId());
+        document.increaseViewCount();
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -12,6 +12,7 @@ import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ public class DocumentServiceImpl implements DocumentService {
     private final CategoryRepository categoryRepository;
     private final DocumentDomainService documentDomainService;
     private final DocumentViewLogService documentViewLogService;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional
@@ -56,7 +58,7 @@ public class DocumentServiceImpl implements DocumentService {
         Document document = documentDomainService.getDocument(id);
 
         if (recordDocumentView(document, viewerUserId, viewerIp)) {
-            document.increaseViewCount();
+            refreshDocumentViewCount(document);
         }
         return document;
     }
@@ -132,5 +134,13 @@ public class DocumentServiceImpl implements DocumentService {
         }
 
         return documentViewLogService.save(document, null, viewerIp);
+    }
+
+    // 조회수 원자 증가 반영 메서드
+    private void refreshDocumentViewCount(Document document) {
+        int updatedCount = documentRepository.incrementViewCount(document.getId());
+        if (updatedCount > 0) {
+            entityManager.refresh(document);
+        }
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/repository/DocumentViewLogRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/repository/DocumentViewLogRepository.java
@@ -17,12 +17,6 @@ public interface DocumentViewLogRepository extends JpaRepository<DocumentViewLog
         LocalDateTime getLastViewedAt();
     }
 
-    // 사용자 기준 최근 조회 로그 개수 조회 메서드
-    long countByDocumentIdAndUserIdAndCreatedAtAfter(Long documentId, Long userId, LocalDateTime createdAt);
-
-    // IP 기준 최근 조회 로그 개수 조회 메서드
-    long countByDocumentIdAndViewerIpAndCreatedAtAfter(Long documentId, String viewerIp, LocalDateTime createdAt);
-
     // 최근 1시간 유효 조회 집계 조회 메서드
     @Query("""
             select l.document.id as documentId,

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushScheduler.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushScheduler.java
@@ -1,0 +1,21 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// 문서 조회수 flush 주기 실행 스케줄러 클래스
+@Component
+@RequiredArgsConstructor
+public class DocumentViewCountFlushScheduler {
+
+    private static final long VIEW_COUNT_FLUSH_DELAY_MILLIS = 60_000L;
+
+    private final DocumentViewCountFlushService documentViewCountFlushService;
+
+    // 문서 조회수 flush 스케줄 호출 메서드
+    @Scheduled(fixedDelay = VIEW_COUNT_FLUSH_DELAY_MILLIS)
+    public void flushPendingViewCounts() {
+        documentViewCountFlushService.flushPendingViewCounts();
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushScheduler.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushScheduler.java
@@ -1,20 +1,25 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 // 문서 조회수 flush 주기 실행 스케줄러 클래스
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(
+        prefix = "app.search",
+        name = "view-count-flush-enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
 public class DocumentViewCountFlushScheduler {
-
-    private static final long VIEW_COUNT_FLUSH_DELAY_MILLIS = 60_000L;
 
     private final DocumentViewCountFlushService documentViewCountFlushService;
 
     // 문서 조회수 flush 스케줄 호출 메서드
-    @Scheduled(fixedDelay = VIEW_COUNT_FLUSH_DELAY_MILLIS)
+    @Scheduled(fixedDelayString = "${app.search.view-count-flush-delay-millis:60000}")
     public void flushPendingViewCounts() {
         documentViewCountFlushService.flushPendingViewCounts();
     }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
@@ -1,10 +1,12 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import java.time.Duration;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class DocumentViewCountFlushService {
 
     private static final String VIEW_COUNT_BUFFER_KEY = "document:view-count:pending";
+    private static final String VIEW_COUNT_FLUSH_LOCK_KEY = "document:view-count:flush-lock";
+    private static final Duration VIEW_COUNT_FLUSH_LOCK_TTL = Duration.ofSeconds(55);
 
     private final StringRedisTemplate stringRedisTemplate;
     private final DocumentRepository documentRepository;
@@ -21,21 +25,29 @@ public class DocumentViewCountFlushService {
     // 문서 조회수 pending flush 메서드
     @Transactional
     public int flushPendingViewCounts() {
-        HashOperations<String, Object, Object> hashOperations = stringRedisTemplate.opsForHash();
-        Map<Object, Object> pendingEntries = hashOperations.entries(VIEW_COUNT_BUFFER_KEY);
-        int flushedCount = 0;
-
-        for (Map.Entry<Object, Object> pendingEntry : pendingEntries.entrySet()) {
-            Long documentId = parseDocumentId(pendingEntry.getKey());
-            long delta = parseViewCountDelta(pendingEntry.getValue());
-
-            if (documentRepository.incrementViewCountBy(documentId, delta) > 0) {
-                hashOperations.delete(VIEW_COUNT_BUFFER_KEY, pendingEntry.getKey().toString());
-                flushedCount++;
-            }
+        if (!tryAcquireFlushLock()) {
+            return 0;
         }
 
-        return flushedCount;
+        HashOperations<String, Object, Object> hashOperations = stringRedisTemplate.opsForHash();
+        try {
+            Map<Object, Object> pendingEntries = hashOperations.entries(VIEW_COUNT_BUFFER_KEY);
+            int flushedCount = 0;
+
+            for (Map.Entry<Object, Object> pendingEntry : pendingEntries.entrySet()) {
+                Long documentId = parseDocumentId(pendingEntry.getKey());
+                long delta = parseViewCountDelta(pendingEntry.getValue());
+
+                if (documentRepository.incrementViewCountBy(documentId, delta) > 0) {
+                    hashOperations.delete(VIEW_COUNT_BUFFER_KEY, pendingEntry.getKey().toString());
+                    flushedCount++;
+                }
+            }
+
+            return flushedCount;
+        } finally {
+            releaseFlushLock();
+        }
     }
 
     // Redis 해시 key 문서 ID 변환 메서드
@@ -46,5 +58,21 @@ public class DocumentViewCountFlushService {
     // Redis 해시 value 조회수 delta 변환 메서드
     private long parseViewCountDelta(Object rawDelta) {
         return Long.parseLong(rawDelta.toString());
+    }
+
+    // flush 분산 락 획득 메서드
+    private boolean tryAcquireFlushLock() {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Boolean acquired = valueOperations.setIfAbsent(
+                VIEW_COUNT_FLUSH_LOCK_KEY,
+                "locked",
+                VIEW_COUNT_FLUSH_LOCK_TTL
+        );
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    // flush 분산 락 해제 메서드
+    private void releaseFlushLock() {
+        stringRedisTemplate.delete(VIEW_COUNT_FLUSH_LOCK_KEY);
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
@@ -1,0 +1,50 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 문서 조회수 Redis 누적값 DB 반영 서비스 클래스
+@Service
+@RequiredArgsConstructor
+public class DocumentViewCountFlushService {
+
+    private static final String VIEW_COUNT_BUFFER_KEY = "document:view-count:pending";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final DocumentRepository documentRepository;
+
+    // 문서 조회수 pending flush 메서드
+    @Transactional
+    public int flushPendingViewCounts() {
+        HashOperations<String, Object, Object> hashOperations = stringRedisTemplate.opsForHash();
+        Map<Object, Object> pendingEntries = hashOperations.entries(VIEW_COUNT_BUFFER_KEY);
+        int flushedCount = 0;
+
+        for (Map.Entry<Object, Object> pendingEntry : pendingEntries.entrySet()) {
+            Long documentId = parseDocumentId(pendingEntry.getKey());
+            long delta = parseViewCountDelta(pendingEntry.getValue());
+
+            if (documentRepository.incrementViewCountBy(documentId, delta) > 0) {
+                hashOperations.delete(VIEW_COUNT_BUFFER_KEY, pendingEntry.getKey().toString());
+                flushedCount++;
+            }
+        }
+
+        return flushedCount;
+    }
+
+    // Redis 해시 key 문서 ID 변환 메서드
+    private Long parseDocumentId(Object rawDocumentId) {
+        return Long.parseLong(rawDocumentId.toString());
+    }
+
+    // Redis 해시 value 조회수 delta 변환 메서드
+    private long parseViewCountDelta(Object rawDelta) {
+        return Long.parseLong(rawDelta.toString());
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DocumentViewCountFlushService {
 
     private static final String VIEW_COUNT_BUFFER_KEY = "document:view-count:pending";
+    private static final String VIEW_COUNT_PROCESSING_KEY = "document:view-count:processing";
     private static final String VIEW_COUNT_FLUSH_LOCK_KEY = "document:view-count:flush-lock";
     private static final Duration VIEW_COUNT_FLUSH_LOCK_TTL = Duration.ofSeconds(55);
 
@@ -31,7 +32,7 @@ public class DocumentViewCountFlushService {
 
         HashOperations<String, Object, Object> hashOperations = stringRedisTemplate.opsForHash();
         try {
-            Map<Object, Object> pendingEntries = hashOperations.entries(VIEW_COUNT_BUFFER_KEY);
+            Map<Object, Object> pendingEntries = drainPendingEntries(hashOperations);
             int flushedCount = 0;
 
             for (Map.Entry<Object, Object> pendingEntry : pendingEntries.entrySet()) {
@@ -39,7 +40,7 @@ public class DocumentViewCountFlushService {
                 long delta = parseViewCountDelta(pendingEntry.getValue());
 
                 if (documentRepository.incrementViewCountBy(documentId, delta) > 0) {
-                    hashOperations.delete(VIEW_COUNT_BUFFER_KEY, pendingEntry.getKey().toString());
+                    hashOperations.delete(VIEW_COUNT_PROCESSING_KEY, pendingEntry.getKey().toString());
                     flushedCount++;
                 }
             }
@@ -58,6 +59,25 @@ public class DocumentViewCountFlushService {
     // Redis 해시 value 조회수 delta 변환 메서드
     private long parseViewCountDelta(Object rawDelta) {
         return Long.parseLong(rawDelta.toString());
+    }
+
+    // pending 해시를 processing 해시로 분리하는 메서드
+    private Map<Object, Object> drainPendingEntries(HashOperations<String, Object, Object> hashOperations) {
+        if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(VIEW_COUNT_PROCESSING_KEY))) {
+            Map<Object, Object> processingEntries = hashOperations.entries(VIEW_COUNT_PROCESSING_KEY);
+            if (!processingEntries.isEmpty()) {
+                return processingEntries;
+            }
+
+            stringRedisTemplate.delete(VIEW_COUNT_PROCESSING_KEY);
+        }
+
+        if (!Boolean.TRUE.equals(stringRedisTemplate.hasKey(VIEW_COUNT_BUFFER_KEY))) {
+            return Map.of();
+        }
+
+        stringRedisTemplate.rename(VIEW_COUNT_BUFFER_KEY, VIEW_COUNT_PROCESSING_KEY);
+        return hashOperations.entries(VIEW_COUNT_PROCESSING_KEY);
     }
 
     // flush 분산 락 획득 메서드

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushService.java
@@ -4,6 +4,7 @@ import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import java.time.Duration;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 // 문서 조회수 Redis 누적값 DB 반영 서비스 클래스
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DocumentViewCountFlushService {
 
@@ -27,6 +29,7 @@ public class DocumentViewCountFlushService {
     @Transactional
     public int flushPendingViewCounts() {
         if (!tryAcquireFlushLock()) {
+            log.debug("문서 조회수 flush 스킵, flush lock 미획득");
             return 0;
         }
 
@@ -42,7 +45,13 @@ public class DocumentViewCountFlushService {
                 if (documentRepository.incrementViewCountBy(documentId, delta) > 0) {
                     hashOperations.delete(VIEW_COUNT_PROCESSING_KEY, pendingEntry.getKey().toString());
                     flushedCount++;
+                } else {
+                    log.warn("문서 조회수 flush 반영 실패, documentId={}, delta={}", documentId, delta);
                 }
+            }
+
+            if (flushedCount > 0) {
+                log.info("문서 조회수 flush 완료, flushedCount={}", flushedCount);
             }
 
             return flushedCount;
@@ -66,6 +75,7 @@ public class DocumentViewCountFlushService {
         if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(VIEW_COUNT_PROCESSING_KEY))) {
             Map<Object, Object> processingEntries = hashOperations.entries(VIEW_COUNT_PROCESSING_KEY);
             if (!processingEntries.isEmpty()) {
+                log.warn("문서 조회수 flush 재개, processingCount={}", processingEntries.size());
                 return processingEntries;
             }
 
@@ -77,7 +87,11 @@ public class DocumentViewCountFlushService {
         }
 
         stringRedisTemplate.rename(VIEW_COUNT_BUFFER_KEY, VIEW_COUNT_PROCESSING_KEY);
-        return hashOperations.entries(VIEW_COUNT_PROCESSING_KEY);
+        Map<Object, Object> processingEntries = hashOperations.entries(VIEW_COUNT_PROCESSING_KEY);
+        if (!processingEntries.isEmpty()) {
+            log.debug("문서 조회수 flush drain 완료, processingCount={}", processingEntries.size());
+        }
+        return processingEntries;
     }
 
     // flush 분산 락 획득 메서드

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
@@ -43,7 +43,12 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
             return false;
         }
 
-        return redisDocumentViewLimiter.isAllowed(document.getId(), viewerUserId, viewerIp);
+        try {
+            return redisDocumentViewLimiter.isAllowed(document.getId(), viewerUserId, viewerIp);
+        } catch (RuntimeException exception) {
+            // Redis 장애 시 문서 조회 API 보호용 fail-open 정책
+            return true;
+        }
     }
 
     // 로그인 사용자 조회자 조회 메서드

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
@@ -1,12 +1,6 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
 import com.jinju.jinjuwiki.domain.document.entity.Document;
-import com.jinju.jinjuwiki.domain.search.entity.DocumentViewLog;
-import com.jinju.jinjuwiki.domain.search.repository.DocumentViewLogRepository;
-import com.jinju.jinjuwiki.domain.user.entity.User;
-import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
-import com.jinju.jinjuwiki.global.error.BusinessException;
-import com.jinju.jinjuwiki.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DocumentViewLogServiceImpl implements DocumentViewLogService {
 
-    private final DocumentViewLogRepository documentViewLogRepository;
-    private final UserRepository userRepository;
     private final RedisDocumentViewLimiter redisDocumentViewLimiter;
     private final RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
 
@@ -28,13 +20,7 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
             return false;
         }
 
-        User viewer = resolveViewer(viewerUserId);
-
-        documentViewLogRepository.save(DocumentViewLog.builder()
-                .document(document)
-                .user(viewer)
-                .viewerIp(viewerIp)
-                .build());
+        // 급상승 집계 Redis 반영 호출
         redisTrendingDocumentViewBuffer.incrementCurrentHourScore(document.getId());
         return true;
     }
@@ -51,16 +37,6 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
             // Redis 장애 시 문서 조회 API 보호용 fail-open 정책
             return true;
         }
-    }
-
-    // 로그인 사용자 조회자 조회 메서드
-    private User resolveViewer(Long viewerUserId) {
-        if (viewerUserId == null) {
-            return null;
-        }
-
-        return userRepository.findById(viewerUserId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     // 비로그인 조회 IP 공백 여부 확인 메서드

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
@@ -7,7 +7,6 @@ import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,19 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DocumentViewLogServiceImpl implements DocumentViewLogService {
 
-    private static final long VIEW_LIMIT_PER_HOUR = 3L;
-
     private final DocumentViewLogRepository documentViewLogRepository;
     private final UserRepository userRepository;
+    private final RedisDocumentViewLimiter redisDocumentViewLimiter;
 
     @Override
     @Transactional
     public boolean save(Document document, Long viewerUserId, String viewerIp) {
-        if (hasExceededUserViewLimit(document, viewerUserId)) {
-            return false;
-        }
-
-        if (hasExceededIpViewLimit(document, viewerUserId, viewerIp)) {
+        if (!isAllowedDocumentView(document, viewerUserId, viewerIp)) {
             return false;
         }
 
@@ -43,6 +37,15 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
         return true;
     }
 
+    // 조회 제한 확인 메서드
+    private boolean isAllowedDocumentView(Document document, Long viewerUserId, String viewerIp) {
+        if (viewerUserId == null && isBlankIp(viewerIp)) {
+            return false;
+        }
+
+        return redisDocumentViewLimiter.isAllowed(document.getId(), viewerUserId, viewerIp);
+    }
+
     // 로그인 사용자 조회자 조회 메서드
     private User resolveViewer(Long viewerUserId) {
         if (viewerUserId == null) {
@@ -51,39 +54,6 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
 
         return userRepository.findById(viewerUserId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    // 로그인 사용자 조회 제한 확인 메서드
-    private boolean hasExceededUserViewLimit(Document document, Long viewerUserId) {
-        if (viewerUserId == null) {
-            return false;
-        }
-
-        long viewCount = documentViewLogRepository.countByDocumentIdAndUserIdAndCreatedAtAfter(
-                document.getId(),
-                viewerUserId,
-                getOneHourAgo()
-        );
-        return viewCount >= VIEW_LIMIT_PER_HOUR;
-    }
-
-    // 비로그인 사용자 조회 제한 확인 메서드
-    private boolean hasExceededIpViewLimit(Document document, Long viewerUserId, String viewerIp) {
-        if (viewerUserId != null || isBlankIp(viewerIp)) {
-            return false;
-        }
-
-        long viewCount = documentViewLogRepository.countByDocumentIdAndViewerIpAndCreatedAtAfter(
-                document.getId(),
-                viewerIp,
-                getOneHourAgo()
-        );
-        return viewCount >= VIEW_LIMIT_PER_HOUR;
-    }
-
-    // 최근 1시간 기준 시각 생성 메서드
-    private LocalDateTime getOneHourAgo() {
-        return LocalDateTime.now().minusHours(1);
     }
 
     // 비로그인 조회 IP 공백 여부 확인 메서드

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
@@ -19,6 +19,7 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
     private final DocumentViewLogRepository documentViewLogRepository;
     private final UserRepository userRepository;
     private final RedisDocumentViewLimiter redisDocumentViewLimiter;
+    private final RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
 
     @Override
     @Transactional
@@ -34,6 +35,7 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
                 .user(viewer)
                 .viewerIp(viewerIp)
                 .build());
+        redisTrendingDocumentViewBuffer.incrementCurrentHourScore(document.getId());
         return true;
     }
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewCountBuffer.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewCountBuffer.java
@@ -1,0 +1,27 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+// Redis 기반 문서 조회수 누적 버퍼 클래스
+@Component
+@RequiredArgsConstructor
+public class RedisDocumentViewCountBuffer {
+
+    private static final String VIEW_COUNT_BUFFER_KEY = "document:view-count:pending";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 문서 조회수 누적 증가 메서드
+    public long increment(Long documentId) {
+        Long updatedCount = stringRedisTemplate.opsForHash()
+                .increment(VIEW_COUNT_BUFFER_KEY, documentId.toString(), 1L);
+
+        if (updatedCount == null) {
+            throw new IllegalStateException("문서 조회수 버퍼 증가 실패");
+        }
+
+        return updatedCount;
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewLimiter.java
@@ -1,0 +1,56 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+// Redis 기반 문서 조회 제한기 클래스
+@Component
+@RequiredArgsConstructor
+public class RedisDocumentViewLimiter {
+
+    private static final long VIEW_LIMIT_PER_HOUR = 3L;
+    private static final Duration VIEW_WINDOW = Duration.ofHours(1);
+    private static final String VIEW_LIMIT_KEY_PREFIX = "document:view-limit";
+    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 조회 허용 여부 확인 메서드
+    public boolean isAllowed(Long documentId, Long viewerUserId, String viewerIp) {
+        String redisKey = createRedisKey(documentId, viewerUserId, viewerIp);
+        Long currentCount = stringRedisTemplate.execute(
+                INCREMENT_WITH_TTL_SCRIPT,
+                List.of(redisKey),
+                String.valueOf(VIEW_WINDOW.toSeconds())
+        );
+
+        return currentCount != null && currentCount <= VIEW_LIMIT_PER_HOUR;
+    }
+
+    // 조회 제한 Redis 키 생성 메서드
+    private String createRedisKey(Long documentId, Long viewerUserId, String viewerIp) {
+        if (viewerUserId != null) {
+            return VIEW_LIMIT_KEY_PREFIX + ":document:" + documentId + ":user:" + viewerUserId;
+        }
+
+        return VIEW_LIMIT_KEY_PREFIX + ":document:" + documentId + ":ip:" + viewerIp;
+    }
+
+    // TTL 포함 증가 Lua 스크립트 생성 메서드
+    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setResultType(Long.class);
+        script.setScriptText("""
+                local current = redis.call('INCR', KEYS[1])
+                if current == 1 then
+                    redis.call('EXPIRE', KEYS[1], ARGV[1])
+                end
+                return current
+                """);
+        return script;
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBuffer.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBuffer.java
@@ -1,0 +1,32 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+// 급상승 문서 Redis 시간대별 집계 버퍼 클래스
+@Component
+@RequiredArgsConstructor
+public class RedisTrendingDocumentViewBuffer {
+
+    private static final String TRENDING_KEY_PREFIX = "search:trending:documents";
+    private static final DateTimeFormatter HOUR_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 현재 시간대 급상승 점수 증가 메서드
+    public Double incrementCurrentHourScore(Long documentId) {
+        String trendingKey = createCurrentHourKey(LocalDateTime.now());
+        ZSetOperations<String, String> zSetOperations = stringRedisTemplate.opsForZSet();
+
+        return zSetOperations.incrementScore(trendingKey, documentId.toString(), 1.0D);
+    }
+
+    // 시간대별 급상승 Redis 키 생성 메서드
+    private String createCurrentHourKey(LocalDateTime now) {
+        return TRENDING_KEY_PREFIX + ":" + now.format(HOUR_KEY_FORMATTER);
+    }
+}

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBuffer.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBuffer.java
@@ -2,6 +2,10 @@ package com.jinju.jinjuwiki.domain.search.service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -12,6 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisTrendingDocumentViewBuffer {
 
+    private static final int TRENDING_FETCH_LIMIT = 20;
     private static final String TRENDING_KEY_PREFIX = "search:trending:documents";
     private static final DateTimeFormatter HOUR_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
 
@@ -25,8 +30,42 @@ public class RedisTrendingDocumentViewBuffer {
         return zSetOperations.incrementScore(trendingKey, documentId.toString(), 1.0D);
     }
 
+    // 최근 1시간 급상승 문서 ID 조회 메서드
+    public List<Long> findTrendingDocumentIds() {
+        ZSetOperations<String, String> zSetOperations = stringRedisTemplate.opsForZSet();
+        LocalDateTime now = LocalDateTime.now();
+        Map<Long, Double> aggregatedScores = new HashMap<>();
+
+        mergeScores(aggregatedScores, zSetOperations.reverseRangeWithScores(createCurrentHourKey(now), 0, TRENDING_FETCH_LIMIT - 1));
+        mergeScores(aggregatedScores, zSetOperations.reverseRangeWithScores(createCurrentHourKey(now.minusHours(1)), 0, TRENDING_FETCH_LIMIT - 1));
+
+        return aggregatedScores.entrySet().stream()
+                .sorted(Map.Entry.<Long, Double>comparingByValue(Comparator.reverseOrder()))
+                .limit(TRENDING_FETCH_LIMIT)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
     // 시간대별 급상승 Redis 키 생성 메서드
     private String createCurrentHourKey(LocalDateTime now) {
         return TRENDING_KEY_PREFIX + ":" + now.format(HOUR_KEY_FORMATTER);
+    }
+
+    // Redis ZSET 점수 병합 메서드
+    private void mergeScores(
+            Map<Long, Double> aggregatedScores,
+            java.util.Set<ZSetOperations.TypedTuple<String>> tuples
+    ) {
+        if (tuples == null || tuples.isEmpty()) {
+            return;
+        }
+
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            if (tuple.getValue() == null || tuple.getScore() == null) {
+                continue;
+            }
+
+            aggregatedScores.merge(Long.parseLong(tuple.getValue()), tuple.getScore(), Double::sum);
+        }
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/TrendingDocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/TrendingDocumentServiceImpl.java
@@ -4,8 +4,6 @@ import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import com.jinju.jinjuwiki.domain.search.dto.response.TrendingDocumentItemResponse;
 import com.jinju.jinjuwiki.domain.search.dto.response.TrendingDocumentsResponse;
-import com.jinju.jinjuwiki.domain.search.repository.DocumentViewLogRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -23,18 +21,18 @@ public class TrendingDocumentServiceImpl implements TrendingDocumentService {
     private static final int TRENDING_DOCUMENT_LIMIT = 5;
     private static final String TRENDING_DESCRIPTION = "최근 1시간 동안 많이 조회된 문서를 보여줍니다.";
 
-    private final DocumentViewLogRepository documentViewLogRepository;
     private final DocumentRepository documentRepository;
+    private final RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
     private final TrendingDocumentTitleFilter trendingDocumentTitleFilter;
     private final TrendingDocumentCandidatePolicy trendingDocumentCandidatePolicy;
 
     @Override
     public TrendingDocumentsResponse getTrendingDocuments() {
-        List<DocumentViewLogRepository.TrendingDocumentProjection> projections = findTrendingProjections();
-        Map<Long, Document> documentMap = findDocuments(projections);
+        List<Long> trendingDocumentIds = redisTrendingDocumentViewBuffer.findTrendingDocumentIds();
+        Map<Long, Document> documentMap = findDocuments(trendingDocumentIds);
 
-        List<TrendingDocumentItemResponse> documents = projections.stream()
-                .map(projection -> documentMap.get(projection.getDocumentId()))
+        List<TrendingDocumentItemResponse> documents = trendingDocumentIds.stream()
+                .map(documentMap::get)
                 .filter(this::isTrendingCandidate)
                 .limit(TRENDING_DOCUMENT_LIMIT)
                 .map(document -> new TrendingDocumentItemResponse(document.getId(), document.getTitle()))
@@ -44,19 +42,9 @@ public class TrendingDocumentServiceImpl implements TrendingDocumentService {
     }
 
     // 집계 대상 문서 조회 메서드
-    private Map<Long, Document> findDocuments(List<DocumentViewLogRepository.TrendingDocumentProjection> projections) {
-        List<Long> documentIds = projections.stream()
-                .map(DocumentViewLogRepository.TrendingDocumentProjection::getDocumentId)
-                .toList();
-
+    private Map<Long, Document> findDocuments(List<Long> documentIds) {
         return documentRepository.findAllById(documentIds).stream()
                 .collect(Collectors.toMap(Document::getId, Function.identity()));
-    }
-
-    // 급상승 문서 집계 조회 메서드
-    private List<DocumentViewLogRepository.TrendingDocumentProjection> findTrendingProjections() {
-        LocalDateTime now = LocalDateTime.now();
-        return documentViewLogRepository.findTrendingDocumentsSince(now.minusHours(1), now.minusHours(3));
     }
 
     // 급상승 문서 후보 판별 메서드

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,12 @@ spring:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:jinjuwiki}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 2s
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,9 @@ app:
     email-verification-expiration-minutes: 5
   mail:
     from: ${MAIL_FROM:${MAIL_USERNAME:no-reply@jinjuwiki.local}}
+  search:
+    view-count-flush-enabled: true
+    view-count-flush-delay-millis: 60000
   upload:
     image-path: uploads/images
     image-url-prefix: /uploads/images/

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
@@ -61,6 +61,24 @@ class DocumentRepositoryTest {
         assertThat(reloadedDocument.getViewCount()).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("문서 조회수 delta 증가 쿼리는 전달한 값만큼 DB 조회수를 증가시킨다.")
+    void incrementViewCountByUpdatesDatabaseValueWithDelta() {
+        // 테스트용 작성자와 카테고리 준비 메서드 호출
+        User author = userRepository.save(createDeltaUser());
+        Category category = categoryRepository.save(createDeltaCategory());
+        Document savedDocument = documentRepository.saveAndFlush(createDeltaDocument(author, category));
+
+        // when
+        int updatedCount = documentRepository.incrementViewCountBy(savedDocument.getId(), 5L);
+
+        // then
+        entityManager.clear();
+        Document reloadedDocument = documentRepository.findById(savedDocument.getId()).orElseThrow();
+        assertThat(updatedCount).isEqualTo(1);
+        assertThat(reloadedDocument.getViewCount()).isEqualTo(5L);
+    }
+
     // 테스트용 사용자 생성 메서드
     private User createUser() {
         return User.builder()
@@ -78,6 +96,13 @@ class DocumentRepositoryTest {
                 .build();
     }
 
+    // delta 테스트용 카테고리 생성 메서드
+    private Category createDeltaCategory() {
+        return Category.builder()
+                .name("조회수-delta")
+                .build();
+    }
+
     // 테스트용 문서 생성 메서드
     private Document createDocument(User author, Category category) {
         ObjectNode contentJson = OBJECT_MAPPER.createObjectNode();
@@ -88,6 +113,33 @@ class DocumentRepositoryTest {
                 .title("조회수 테스트 문서")
                 .content(contentJson.toString())
                 .summary("조회수 테스트 요약")
+                .eventYear(2026)
+                .contentJson(contentJson.toString())
+                .author(author)
+                .category(category)
+                .build();
+    }
+
+    // delta 테스트용 사용자 생성 메서드
+    private User createDeltaUser() {
+        return User.builder()
+                .email("view-count-delta@test.com")
+                .password("encoded-password")
+                .nickname("viewCounterDelta")
+                .role(UserRole.USER)
+                .build();
+    }
+
+    // delta 테스트용 문서 생성 메서드
+    private Document createDeltaDocument(User author, Category category) {
+        ObjectNode contentJson = OBJECT_MAPPER.createObjectNode();
+        contentJson.put("type", "doc");
+        contentJson.putArray("content");
+
+        return Document.builder()
+                .title("조회수 delta 테스트 문서")
+                .content(contentJson.toString())
+                .summary("조회수 delta 테스트 요약")
                 .eventYear(2026)
                 .contentJson(contentJson.toString())
                 .author(author)

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
@@ -11,6 +11,7 @@ import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.entity.UserRole;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.config.JpaAuditingConfig;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,16 +28,19 @@ class DocumentRepositoryTest {
     private final DocumentRepository documentRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final EntityManager entityManager;
 
     @Autowired
     DocumentRepositoryTest(
             DocumentRepository documentRepository,
             UserRepository userRepository,
-            CategoryRepository categoryRepository
+            CategoryRepository categoryRepository,
+            EntityManager entityManager
     ) {
         this.documentRepository = documentRepository;
         this.userRepository = userRepository;
         this.categoryRepository = categoryRepository;
+        this.entityManager = entityManager;
     }
 
     @Test
@@ -51,6 +55,7 @@ class DocumentRepositoryTest {
         int updatedCount = documentRepository.incrementViewCount(savedDocument.getId());
 
         // then
+        entityManager.clear();
         Document reloadedDocument = documentRepository.findById(savedDocument.getId()).orElseThrow();
         assertThat(updatedCount).isEqualTo(1);
         assertThat(reloadedDocument.getViewCount()).isEqualTo(1L);

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.jinju.jinjuwiki.domain.document.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jinju.jinjuwiki.domain.category.entity.Category;
+import com.jinju.jinjuwiki.domain.category.repository.CategoryRepository;
+import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.user.entity.User;
+import com.jinju.jinjuwiki.domain.user.entity.UserRole;
+import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
+import com.jinju.jinjuwiki.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+// 문서 저장소 원자 증가 쿼리 테스트 클래스
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class DocumentRepositoryTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final DocumentRepository documentRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Autowired
+    DocumentRepositoryTest(
+            DocumentRepository documentRepository,
+            UserRepository userRepository,
+            CategoryRepository categoryRepository
+    ) {
+        this.documentRepository = documentRepository;
+        this.userRepository = userRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Test
+    @DisplayName("문서 조회수 원자 증가 쿼리는 DB 값 기준으로 조회수를 1 증가시킨다.")
+    void incrementViewCountUpdatesDatabaseValueAtomically() {
+        // 테스트용 작성자와 카테고리 준비 메서드 호출
+        User author = userRepository.save(createUser());
+        Category category = categoryRepository.save(createCategory());
+        Document savedDocument = documentRepository.saveAndFlush(createDocument(author, category));
+
+        // when
+        int updatedCount = documentRepository.incrementViewCount(savedDocument.getId());
+
+        // then
+        Document reloadedDocument = documentRepository.findById(savedDocument.getId()).orElseThrow();
+        assertThat(updatedCount).isEqualTo(1);
+        assertThat(reloadedDocument.getViewCount()).isEqualTo(1L);
+    }
+
+    // 테스트용 사용자 생성 메서드
+    private User createUser() {
+        return User.builder()
+                .email("view-count@test.com")
+                .password("encoded-password")
+                .nickname("viewCounter")
+                .role(UserRole.USER)
+                .build();
+    }
+
+    // 테스트용 카테고리 생성 메서드
+    private Category createCategory() {
+        return Category.builder()
+                .name("조회수")
+                .build();
+    }
+
+    // 테스트용 문서 생성 메서드
+    private Document createDocument(User author, Category category) {
+        ObjectNode contentJson = OBJECT_MAPPER.createObjectNode();
+        contentJson.put("type", "doc");
+        contentJson.putArray("content");
+
+        return Document.builder()
+                .title("조회수 테스트 문서")
+                .content(contentJson.toString())
+                .summary("조회수 테스트 요약")
+                .eventYear(2026)
+                .contentJson(contentJson.toString())
+                .author(author)
+                .category(category)
+                .build();
+    }
+}

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,7 @@ import com.jinju.jinjuwiki.domain.user.entity.UserRole;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +59,9 @@ class DocumentServiceTest {
 
     @Mock
     private DocumentViewLogService documentViewLogService;
+
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private DocumentServiceImpl documentService;
@@ -144,6 +149,11 @@ class DocumentServiceTest {
 
         when(documentDomainService.getDocument(200L)).thenReturn(document);
         when(documentViewLogService.save(document, 2L, null)).thenReturn(true);
+        when(documentRepository.incrementViewCount(200L)).thenReturn(1);
+        doAnswer(invocation -> {
+            ReflectionTestUtils.setField(document, "viewCount", 1L);
+            return null;
+        }).when(entityManager).refresh(document);
 
         // when
         Document response = documentService.getDocument(200L, 2L, "127.0.0.1");
@@ -153,6 +163,8 @@ class DocumentServiceTest {
         assertThat(response.getViewCount()).isEqualTo(1L);
         verify(documentDomainService).getDocument(200L);
         verify(documentViewLogService).save(document, 2L, null);
+        verify(documentRepository).incrementViewCount(200L);
+        verify(entityManager).refresh(document);
     }
 
     @Test

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -20,12 +19,12 @@ import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import com.jinju.jinjuwiki.domain.document.support.DocumentContentJsonCodec;
 import com.jinju.jinjuwiki.domain.search.service.DocumentViewLogService;
+import com.jinju.jinjuwiki.domain.search.service.RedisDocumentViewCountBuffer;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.entity.UserRole;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -61,7 +60,7 @@ class DocumentServiceTest {
     private DocumentViewLogService documentViewLogService;
 
     @Mock
-    private EntityManager entityManager;
+    private RedisDocumentViewCountBuffer redisDocumentViewCountBuffer;
 
     @InjectMocks
     private DocumentServiceImpl documentService;
@@ -149,11 +148,7 @@ class DocumentServiceTest {
 
         when(documentDomainService.getDocument(200L)).thenReturn(document);
         when(documentViewLogService.save(document, 2L, null)).thenReturn(true);
-        when(documentRepository.incrementViewCount(200L)).thenReturn(1);
-        doAnswer(invocation -> {
-            ReflectionTestUtils.setField(document, "viewCount", 1L);
-            return null;
-        }).when(entityManager).refresh(document);
+        when(redisDocumentViewCountBuffer.increment(200L)).thenReturn(1L);
 
         // when
         Document response = documentService.getDocument(200L, 2L, "127.0.0.1");
@@ -163,8 +158,7 @@ class DocumentServiceTest {
         assertThat(response.getViewCount()).isEqualTo(1L);
         verify(documentDomainService).getDocument(200L);
         verify(documentViewLogService).save(document, 2L, null);
-        verify(documentRepository).incrementViewCount(200L);
-        verify(entityManager).refresh(document);
+        verify(redisDocumentViewCountBuffer).increment(200L);
     }
 
     @Test

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushSchedulerTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushSchedulerTest.java
@@ -1,0 +1,31 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+// 문서 조회수 flush 스케줄러 단위 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class DocumentViewCountFlushSchedulerTest {
+
+    @Mock
+    private DocumentViewCountFlushService documentViewCountFlushService;
+
+    @InjectMocks
+    private DocumentViewCountFlushScheduler documentViewCountFlushScheduler;
+
+    @Test
+    @DisplayName("문서 조회수 flush 스케줄러는 flush 서비스를 호출한다.")
+    void flushPendingViewCountsCallsFlushService() {
+        // when
+        documentViewCountFlushScheduler.flushPendingViewCounts();
+
+        // then
+        verify(documentViewCountFlushService).flushPendingViewCounts();
+    }
+}

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
@@ -45,7 +45,9 @@ class DocumentViewCountFlushServiceTest {
         when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
         when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
                 .thenReturn(true);
-        when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3", "11", "2"));
+        when(stringRedisTemplate.hasKey("document:view-count:processing")).thenReturn(false);
+        when(stringRedisTemplate.hasKey("document:view-count:pending")).thenReturn(true);
+        when(hashOperations.entries("document:view-count:processing")).thenReturn(Map.of("10", "3", "11", "2"));
         when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(1);
         when(documentRepository.incrementViewCountBy(11L, 2L)).thenReturn(1);
 
@@ -56,8 +58,9 @@ class DocumentViewCountFlushServiceTest {
         assertThat(flushedCount).isEqualTo(2);
         verify(documentRepository).incrementViewCountBy(10L, 3L);
         verify(documentRepository).incrementViewCountBy(11L, 2L);
-        verify(hashOperations).delete("document:view-count:pending", "10");
-        verify(hashOperations).delete("document:view-count:pending", "11");
+        verify(stringRedisTemplate).rename("document:view-count:pending", "document:view-count:processing");
+        verify(hashOperations).delete("document:view-count:processing", "10");
+        verify(hashOperations).delete("document:view-count:processing", "11");
         verify(stringRedisTemplate).delete("document:view-count:flush-lock");
     }
 
@@ -69,7 +72,9 @@ class DocumentViewCountFlushServiceTest {
         when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
         when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
                 .thenReturn(true);
-        when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3"));
+        when(stringRedisTemplate.hasKey("document:view-count:processing")).thenReturn(false);
+        when(stringRedisTemplate.hasKey("document:view-count:pending")).thenReturn(true);
+        when(hashOperations.entries("document:view-count:processing")).thenReturn(Map.of("10", "3"));
         when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(0);
 
         // when
@@ -78,7 +83,8 @@ class DocumentViewCountFlushServiceTest {
         // then
         assertThat(flushedCount).isZero();
         verify(documentRepository).incrementViewCountBy(10L, 3L);
-        verify(hashOperations, never()).delete("document:view-count:pending", "10");
+        verify(stringRedisTemplate).rename("document:view-count:pending", "document:view-count:processing");
+        verify(hashOperations, never()).delete("document:view-count:processing", "10");
         verify(stringRedisTemplate).delete("document:view-count:flush-lock");
     }
 
@@ -98,5 +104,28 @@ class DocumentViewCountFlushServiceTest {
         verify(documentRepository, never()).incrementViewCountBy(10L, 3L);
         verify(stringRedisTemplate, never()).opsForHash();
         verify(stringRedisTemplate, never()).delete("document:view-count:flush-lock");
+    }
+
+    @Test
+    @DisplayName("기존 processing 조회수가 남아 있으면 pending rename 없이 이어서 flush 한다.")
+    void flushPendingViewCountsContinueProcessingEntries() {
+        // flush 대상 Redis 해시 준비 메서드
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
+                .thenReturn(true);
+        when(stringRedisTemplate.hasKey("document:view-count:processing")).thenReturn(true);
+        when(hashOperations.entries("document:view-count:processing")).thenReturn(Map.of("10", "4"));
+        when(documentRepository.incrementViewCountBy(10L, 4L)).thenReturn(1);
+
+        // when
+        int flushedCount = documentViewCountFlushService.flushPendingViewCounts();
+
+        // then
+        assertThat(flushedCount).isEqualTo(1);
+        verify(documentRepository).incrementViewCountBy(10L, 4L);
+        verify(stringRedisTemplate, never()).rename("document:view-count:pending", "document:view-count:processing");
+        verify(hashOperations).delete("document:view-count:processing", "10");
+        verify(stringRedisTemplate).delete("document:view-count:flush-lock");
     }
 }

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
@@ -1,0 +1,71 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+// 문서 조회수 flush 서비스 단위 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class DocumentViewCountFlushServiceTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @InjectMocks
+    private DocumentViewCountFlushService documentViewCountFlushService;
+
+    @Test
+    @DisplayName("pending 조회수는 문서별 delta 만큼 DB에 반영 후 Redis 해시에서 제거한다.")
+    void flushPendingViewCountsSuccess() {
+        // flush 대상 Redis 해시 준비 메서드
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3", "11", "2"));
+        when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(1);
+        when(documentRepository.incrementViewCountBy(11L, 2L)).thenReturn(1);
+
+        // when
+        int flushedCount = documentViewCountFlushService.flushPendingViewCounts();
+
+        // then
+        assertThat(flushedCount).isEqualTo(2);
+        verify(documentRepository).incrementViewCountBy(10L, 3L);
+        verify(documentRepository).incrementViewCountBy(11L, 2L);
+        verify(hashOperations).delete("document:view-count:pending", "10");
+        verify(hashOperations).delete("document:view-count:pending", "11");
+    }
+
+    @Test
+    @DisplayName("DB 반영 대상이 없으면 Redis pending 데이터는 삭제하지 않는다.")
+    void flushPendingViewCountsSkipDeleteWhenUpdateTargetMissing() {
+        // flush 대상 Redis 해시 준비 메서드
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3"));
+        when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(0);
+
+        // when
+        int flushedCount = documentViewCountFlushService.flushPendingViewCounts();
+
+        // then
+        assertThat(flushedCount).isZero();
+        verify(documentRepository).incrementViewCountBy(10L, 3L);
+        verify(hashOperations, never()).delete("document:view-count:pending", "10");
+    }
+}

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewCountFlushServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 // 문서 조회수 flush 서비스 단위 테스트 클래스
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +31,9 @@ class DocumentViewCountFlushServiceTest {
     @Mock
     private HashOperations<String, Object, Object> hashOperations;
 
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     @InjectMocks
     private DocumentViewCountFlushService documentViewCountFlushService;
 
@@ -36,7 +41,10 @@ class DocumentViewCountFlushServiceTest {
     @DisplayName("pending 조회수는 문서별 delta 만큼 DB에 반영 후 Redis 해시에서 제거한다.")
     void flushPendingViewCountsSuccess() {
         // flush 대상 Redis 해시 준비 메서드
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
+                .thenReturn(true);
         when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3", "11", "2"));
         when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(1);
         when(documentRepository.incrementViewCountBy(11L, 2L)).thenReturn(1);
@@ -50,13 +58,17 @@ class DocumentViewCountFlushServiceTest {
         verify(documentRepository).incrementViewCountBy(11L, 2L);
         verify(hashOperations).delete("document:view-count:pending", "10");
         verify(hashOperations).delete("document:view-count:pending", "11");
+        verify(stringRedisTemplate).delete("document:view-count:flush-lock");
     }
 
     @Test
     @DisplayName("DB 반영 대상이 없으면 Redis pending 데이터는 삭제하지 않는다.")
     void flushPendingViewCountsSkipDeleteWhenUpdateTargetMissing() {
         // flush 대상 Redis 해시 준비 메서드
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
+                .thenReturn(true);
         when(hashOperations.entries("document:view-count:pending")).thenReturn(Map.of("10", "3"));
         when(documentRepository.incrementViewCountBy(10L, 3L)).thenReturn(0);
 
@@ -67,5 +79,24 @@ class DocumentViewCountFlushServiceTest {
         assertThat(flushedCount).isZero();
         verify(documentRepository).incrementViewCountBy(10L, 3L);
         verify(hashOperations, never()).delete("document:view-count:pending", "10");
+        verify(stringRedisTemplate).delete("document:view-count:flush-lock");
+    }
+
+    @Test
+    @DisplayName("flush 락을 획득하지 못하면 DB 반영 없이 즉시 종료한다.")
+    void flushPendingViewCountsSkipWhenLockNotAcquired() {
+        // flush 락 준비 메서드
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent("document:view-count:flush-lock", "locked", Duration.ofSeconds(55)))
+                .thenReturn(false);
+
+        // when
+        int flushedCount = documentViewCountFlushService.flushPendingViewCounts();
+
+        // then
+        assertThat(flushedCount).isZero();
+        verify(documentRepository, never()).incrementViewCountBy(10L, 3L);
+        verify(stringRedisTemplate, never()).opsForHash();
+        verify(stringRedisTemplate, never()).delete("document:view-count:flush-lock");
     }
 }

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
@@ -1,19 +1,14 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jinju.jinjuwiki.domain.category.entity.Category;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
-import com.jinju.jinjuwiki.domain.search.entity.DocumentViewLog;
-import com.jinju.jinjuwiki.domain.search.repository.DocumentViewLogRepository;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.entity.UserRole;
-import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,12 +20,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 // 문서 조회 로그 서비스 단위 테스트 클래스
 @ExtendWith(MockitoExtension.class)
 class DocumentViewLogServiceTest {
-
-    @Mock
-    private DocumentViewLogRepository documentViewLogRepository;
-
-    @Mock
-    private UserRepository userRepository;
 
     @Mock
     private RedisDocumentViewLimiter redisDocumentViewLimiter;
@@ -46,15 +35,12 @@ class DocumentViewLogServiceTest {
     void saveUserViewLogSuccess() {
         // given
         Document document = createDocument(1L, "급상승 문서");
-        User user = createUser(2L, "viewer@test.com", "viewer");
-        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
         when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenReturn(true);
 
         // when
         documentViewLogService.save(document, 2L, null);
 
         // then
-        verify(documentViewLogRepository).save(any(DocumentViewLog.class));
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
         verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }
@@ -70,9 +56,8 @@ class DocumentViewLogServiceTest {
         documentViewLogService.save(document, 2L, null);
 
         // then
-        verify(documentViewLogRepository, never()).save(any(DocumentViewLog.class));
-        verify(userRepository, never()).findById(any());
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
+        verify(redisTrendingDocumentViewBuffer, never()).incrementCurrentHourScore(any());
     }
 
     @Test
@@ -86,8 +71,8 @@ class DocumentViewLogServiceTest {
         documentViewLogService.save(document, null, "127.0.0.1");
 
         // then
-        verify(documentViewLogRepository, never()).save(any(DocumentViewLog.class));
         verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
+        verify(redisTrendingDocumentViewBuffer, never()).incrementCurrentHourScore(any());
     }
 
     @Test
@@ -101,7 +86,6 @@ class DocumentViewLogServiceTest {
         documentViewLogService.save(document, null, "127.0.0.1");
 
         // then
-        verify(documentViewLogRepository).save(any(DocumentViewLog.class));
         verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
         verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }
@@ -111,16 +95,12 @@ class DocumentViewLogServiceTest {
     void saveViewLogSuccessWhenRedisLimiterFails() {
         // given
         Document document = createDocument(1L, "급상승 문서");
-        User user = createUser(2L, "viewer@test.com", "viewer");
-        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
         when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenThrow(new RuntimeException("redis unavailable"));
 
         // when
         documentViewLogService.save(document, 2L, null);
 
         // then
-        verify(documentViewLogRepository).save(any(DocumentViewLog.class));
-        verify(userRepository).findById(2L);
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
         verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
@@ -35,6 +35,9 @@ class DocumentViewLogServiceTest {
     @Mock
     private RedisDocumentViewLimiter redisDocumentViewLimiter;
 
+    @Mock
+    private RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
+
     @InjectMocks
     private DocumentViewLogServiceImpl documentViewLogService;
 
@@ -53,6 +56,7 @@ class DocumentViewLogServiceTest {
         // then
         verify(documentViewLogRepository).save(any(DocumentViewLog.class));
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
+        verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }
 
     @Test
@@ -99,6 +103,7 @@ class DocumentViewLogServiceTest {
         // then
         verify(documentViewLogRepository).save(any(DocumentViewLog.class));
         verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
+        verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }
 
     @Test
@@ -117,6 +122,7 @@ class DocumentViewLogServiceTest {
         verify(documentViewLogRepository).save(any(DocumentViewLog.class));
         verify(userRepository).findById(2L);
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
+        verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }
 
     // 테스트용 사용자 생성 메서드

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
@@ -32,6 +32,9 @@ class DocumentViewLogServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private RedisDocumentViewLimiter redisDocumentViewLimiter;
+
     @InjectMocks
     private DocumentViewLogServiceImpl documentViewLogService;
 
@@ -42,14 +45,14 @@ class DocumentViewLogServiceTest {
         Document document = createDocument(1L, "급상승 문서");
         User user = createUser(2L, "viewer@test.com", "viewer");
         when(userRepository.findById(2L)).thenReturn(Optional.of(user));
-        when(documentViewLogRepository.countByDocumentIdAndUserIdAndCreatedAtAfter(eq(1L), eq(2L), any()))
-                .thenReturn(0L);
+        when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenReturn(true);
 
         // when
         documentViewLogService.save(document, 2L, null);
 
         // then
         verify(documentViewLogRepository).save(any(DocumentViewLog.class));
+        verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
     }
 
     @Test
@@ -57,8 +60,7 @@ class DocumentViewLogServiceTest {
     void saveUserViewLogSkipWhenUserLimitExceeded() {
         // given
         Document document = createDocument(1L, "급상승 문서");
-        when(documentViewLogRepository.countByDocumentIdAndUserIdAndCreatedAtAfter(eq(1L), eq(2L), any()))
-                .thenReturn(3L);
+        when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenReturn(false);
 
         // when
         documentViewLogService.save(document, 2L, null);
@@ -66,6 +68,7 @@ class DocumentViewLogServiceTest {
         // then
         verify(documentViewLogRepository, never()).save(any(DocumentViewLog.class));
         verify(userRepository, never()).findById(any());
+        verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
     }
 
     @Test
@@ -73,14 +76,14 @@ class DocumentViewLogServiceTest {
     void saveAnonymousViewLogSkipWhenIpLimitExceeded() {
         // given
         Document document = createDocument(1L, "급상승 문서");
-        when(documentViewLogRepository.countByDocumentIdAndViewerIpAndCreatedAtAfter(eq(1L), eq("127.0.0.1"), any()))
-                .thenReturn(3L);
+        when(redisDocumentViewLimiter.isAllowed(1L, null, "127.0.0.1")).thenReturn(false);
 
         // when
         documentViewLogService.save(document, null, "127.0.0.1");
 
         // then
         verify(documentViewLogRepository, never()).save(any(DocumentViewLog.class));
+        verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
     }
 
     @Test
@@ -88,14 +91,14 @@ class DocumentViewLogServiceTest {
     void saveAnonymousViewLogSuccess() {
         // given
         Document document = createDocument(1L, "급상승 문서");
-        when(documentViewLogRepository.countByDocumentIdAndViewerIpAndCreatedAtAfter(eq(1L), eq("127.0.0.1"), any()))
-                .thenReturn(2L);
+        when(redisDocumentViewLimiter.isAllowed(1L, null, "127.0.0.1")).thenReturn(true);
 
         // when
         documentViewLogService.save(document, null, "127.0.0.1");
 
         // then
         verify(documentViewLogRepository).save(any(DocumentViewLog.class));
+        verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
     }
 
     // 테스트용 사용자 생성 메서드

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
@@ -101,6 +101,24 @@ class DocumentViewLogServiceTest {
         verify(redisDocumentViewLimiter).isAllowed(1L, null, "127.0.0.1");
     }
 
+    @Test
+    @DisplayName("Redis limiter 장애가 발생해도 문서 조회 로그 저장은 계속 진행한다.")
+    void saveViewLogSuccessWhenRedisLimiterFails() {
+        // given
+        Document document = createDocument(1L, "급상승 문서");
+        User user = createUser(2L, "viewer@test.com", "viewer");
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenThrow(new RuntimeException("redis unavailable"));
+
+        // when
+        documentViewLogService.save(document, 2L, null);
+
+        // then
+        verify(documentViewLogRepository).save(any(DocumentViewLog.class));
+        verify(userRepository).findById(2L);
+        verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
+    }
+
     // 테스트용 사용자 생성 메서드
     private User createUser(Long id, String email, String nickname) {
         User user = User.builder()

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewCountBufferTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewCountBufferTest.java
@@ -1,0 +1,61 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+// 문서 조회수 Redis 버퍼 단위 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class RedisDocumentViewCountBufferTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @InjectMocks
+    private RedisDocumentViewCountBuffer redisDocumentViewCountBuffer;
+
+    @Test
+    @DisplayName("문서 조회수 버퍼는 Redis 해시 필드를 1 증가시킨다.")
+    void incrementSuccess() {
+        // given
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.increment("document:view-count:pending", "10", 1L)).thenReturn(3L);
+
+        // when
+        long updatedCount = redisDocumentViewCountBuffer.increment(10L);
+
+        // then
+        assertThat(updatedCount).isEqualTo(3L);
+        verify(hashOperations).increment("document:view-count:pending", "10", 1L);
+    }
+
+    @Test
+    @DisplayName("문서 조회수 버퍼 증가 결과가 없으면 예외를 발생시킨다.")
+    void incrementFailWhenRedisReturnsNull() {
+        // given
+        when(stringRedisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(hashOperations.increment("document:view-count:pending", "10", 1L)).thenReturn(null);
+
+        // when
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> redisDocumentViewCountBuffer.increment(10L)
+        );
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("문서 조회수 버퍼 증가 실패");
+    }
+}

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBufferTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/RedisTrendingDocumentViewBufferTest.java
@@ -1,0 +1,52 @@
+package com.jinju.jinjuwiki.domain.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+// 급상승 문서 Redis 버퍼 단위 테스트 클래스
+@ExtendWith(MockitoExtension.class)
+class RedisTrendingDocumentViewBufferTest {
+
+    private static final DateTimeFormatter HOUR_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    @InjectMocks
+    private RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
+
+    @Test
+    @DisplayName("현재 시간대 Redis ZSET 점수를 1 증가시킨다.")
+    void incrementCurrentHourScoreSuccess() {
+        LocalDateTime fixedNow = LocalDateTime.of(2026, 4, 10, 22, 0);
+        String expectedKey = "search:trending:documents:" + fixedNow.format(HOUR_KEY_FORMATTER);
+
+        when(stringRedisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(zSetOperations.incrementScore(expectedKey, "10", 1.0D)).thenReturn(4.0D);
+
+        try (MockedStatic<LocalDateTime> mockedLocalDateTime = org.mockito.Mockito.mockStatic(LocalDateTime.class)) {
+            mockedLocalDateTime.when(LocalDateTime::now).thenReturn(fixedNow);
+
+            Double updatedScore = redisTrendingDocumentViewBuffer.incrementCurrentHourScore(10L);
+
+            assertThat(updatedScore).isEqualTo(4.0D);
+            verify(zSetOperations).incrementScore(expectedKey, "10", 1.0D);
+        }
+    }
+}

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/TrendingDocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/TrendingDocumentServiceTest.java
@@ -7,10 +7,8 @@ import com.jinju.jinjuwiki.domain.category.entity.Category;
 import com.jinju.jinjuwiki.domain.document.entity.Document;
 import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import com.jinju.jinjuwiki.domain.search.dto.response.TrendingDocumentsResponse;
-import com.jinju.jinjuwiki.domain.search.repository.DocumentViewLogRepository;
 import com.jinju.jinjuwiki.domain.user.entity.User;
 import com.jinju.jinjuwiki.domain.user.entity.UserRole;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,10 +23,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 class TrendingDocumentServiceTest {
 
     @Mock
-    private DocumentViewLogRepository documentViewLogRepository;
+    private DocumentRepository documentRepository;
 
     @Mock
-    private DocumentRepository documentRepository;
+    private RedisTrendingDocumentViewBuffer redisTrendingDocumentViewBuffer;
 
     @Mock
     private TrendingDocumentTitleFilter trendingDocumentTitleFilter;
@@ -43,14 +41,7 @@ class TrendingDocumentServiceTest {
     @DisplayName("급상승 문서는 집계 정렬 순서를 유지하고 상위 5개만 반환한다.")
     void getTrendingDocumentsSuccess() {
         // given
-        List<DocumentViewLogRepository.TrendingDocumentProjection> projections = List.of(
-                createProjection(2L, 20L, LocalDateTime.of(2026, 4, 10, 12, 0)),
-                createProjection(3L, 20L, LocalDateTime.of(2026, 4, 10, 11, 59)),
-                createProjection(1L, 15L, LocalDateTime.of(2026, 4, 10, 11, 58)),
-                createProjection(4L, 10L, LocalDateTime.of(2026, 4, 10, 11, 57)),
-                createProjection(5L, 8L, LocalDateTime.of(2026, 4, 10, 11, 56)),
-                createProjection(6L, 7L, LocalDateTime.of(2026, 4, 10, 11, 55))
-        );
+        List<Long> trendingDocumentIds = List.of(2L, 3L, 1L, 4L, 5L, 6L);
         List<Document> documents = List.of(
                 createDocument(1L, "문서 1"),
                 createDocument(2L, "문서 2"),
@@ -59,8 +50,7 @@ class TrendingDocumentServiceTest {
                 createDocument(5L, "문서 5"),
                 createDocument(6L, "문서 6")
         );
-        when(documentViewLogRepository.findTrendingDocumentsSince(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
-                .thenReturn(projections);
+        when(redisTrendingDocumentViewBuffer.findTrendingDocumentIds()).thenReturn(trendingDocumentIds);
         when(documentRepository.findAllById(List.of(2L, 3L, 1L, 4L, 5L, 6L))).thenReturn(documents);
         when(trendingDocumentCandidatePolicy.matchesDocumentState(org.mockito.ArgumentMatchers.any())).thenReturn(true);
         when(trendingDocumentTitleFilter.isExcludedTitle(org.mockito.ArgumentMatchers.anyString())).thenReturn(false);
@@ -76,30 +66,6 @@ class TrendingDocumentServiceTest {
         assertThat(response.documents().get(2).documentId()).isEqualTo(1L);
         assertThat(response.documents().get(3).documentId()).isEqualTo(4L);
         assertThat(response.documents().get(4).documentId()).isEqualTo(5L);
-    }
-
-    // 테스트용 집계 projection 생성 메서드
-    private DocumentViewLogRepository.TrendingDocumentProjection createProjection(
-            Long documentId,
-            long viewCount,
-            LocalDateTime lastViewedAt
-    ) {
-        return new DocumentViewLogRepository.TrendingDocumentProjection() {
-            @Override
-            public Long getDocumentId() {
-                return documentId;
-            }
-
-            @Override
-            public long getViewCount() {
-                return viewCount;
-            }
-
-            @Override
-            public LocalDateTime getLastViewedAt() {
-                return lastViewedAt;
-            }
-        };
     }
 
     // 테스트용 문서 생성 메서드


### PR DESCRIPTION
## 작업 내용
- REDIS를 도입하여 실시간 검색어 API 구조 변경

## 변경 이유
- 즉, 문서 자체 조회 외에 동기 DB 쓰기 2회 + 읽기 1회 이상이 붙었기 때문

## 관련 이슈
- #84 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
