### PR TITLE
feat : 학교 문서 기준 학교별 카테고리 트리와 문서 소속 구조 추가

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/category/dto/response/CategoryResponse.java
@@ -7,17 +7,19 @@ import java.util.List;
 public record CategoryResponse(
         @Schema(description = "카테고리 ID", example = "1")
         Long categoryId,
+        @Schema(description = "학교 문서 ID", example = "101", nullable = true)
+        Long schoolDocumentId,
         @Schema(description = "카테고리 이름", example = "역사")
         String name,
         @Schema(description = "하위 카테고리 목록")
         List<CategoryResponse> children
 ) {
 
-    public static CategoryResponse leaf(Long categoryId, String name) {
-        return new CategoryResponse(categoryId, name, List.of());
+    public static CategoryResponse leaf(Long categoryId, Long schoolDocumentId, String name) {
+        return new CategoryResponse(categoryId, schoolDocumentId, name, List.of());
     }
 
-    public static CategoryResponse parent(Long categoryId, String name, List<CategoryResponse> children) {
-        return new CategoryResponse(categoryId, name, children);
+    public static CategoryResponse parent(Long categoryId, Long schoolDocumentId, String name, List<CategoryResponse> children) {
+        return new CategoryResponse(categoryId, schoolDocumentId, name, children);
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/category/service/CategoryServiceImpl.java
@@ -4,6 +4,8 @@ import com.jinju.jinjuwiki.domain.category.dto.response.CategoryResponse;
 import com.jinju.jinjuwiki.domain.category.entity.Category;
 import com.jinju.jinjuwiki.domain.category.entity.CategoryType;
 import com.jinju.jinjuwiki.domain.category.repository.CategoryRepository;
+import com.jinju.jinjuwiki.domain.document.entity.Document;
+import com.jinju.jinjuwiki.domain.document.repository.DocumentRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +26,7 @@ public class CategoryServiceImpl implements CategoryService {
     );
 
     private final CategoryRepository categoryRepository;
+    private final DocumentRepository documentRepository;
 
     @Override
     public List<CategoryResponse> getCategories() {
@@ -37,23 +40,28 @@ public class CategoryServiceImpl implements CategoryService {
         List<CategoryResponse> responses = new ArrayList<>();
 
         if (schoolCategory != null) {
-            List<CategoryResponse> schoolChildren = SCHOOL_CHILDREN.stream()
+            List<Document> schoolDocuments = documentRepository.findByCategoryIdOrderByTitleAsc(schoolCategory.getId());
+            List<Category> schoolChildren = SCHOOL_CHILDREN.stream()
                     .map(categoriesByName::get)
                     .filter(Objects::nonNull)
-                    .map(category -> CategoryResponse.leaf(category.getId(), category.getName()))
                     .toList();
 
-            responses.add(CategoryResponse.parent(
-                    schoolCategory.getId(),
-                    schoolCategory.getName(),
-                    schoolChildren
-            ));
+            schoolDocuments.stream()
+                    .map(document -> CategoryResponse.parent(
+                            schoolCategory.getId(),
+                            document.getId(),
+                            document.getTitle(),
+                            schoolChildren.stream()
+                                    .map(category -> CategoryResponse.leaf(category.getId(), document.getId(), category.getName()))
+                                    .toList()
+                    ))
+                    .forEach(responses::add);
         }
 
         categories.stream()
                 .filter(category -> !category.getName().equals(CategoryType.SCHOOL.getDisplayName()))
                 .filter(category -> !schoolChildNames.contains(category.getName()))
-                .map(category -> CategoryResponse.leaf(category.getId(), category.getName()))
+                .map(category -> CategoryResponse.leaf(category.getId(), null, category.getName()))
                 .forEach(responses::add);
 
         return responses;

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/controller/DocumentController.java
@@ -131,10 +131,11 @@ public class DocumentController {
     // 문서 목록 조회 응답 코드 명세
     public ResponseEntity<ApiResponse<PageResponse<DocumentSummaryResponse>>> getDocuments(
             @RequestParam(required = false) Long categoryId, // 카테고리 필터
+            @RequestParam(required = false) Long schoolDocumentId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        PageResponse<DocumentSummaryResponse> response = documentService.getDocuments(categoryId, page, size);
+        PageResponse<DocumentSummaryResponse> response = documentService.getDocuments(categoryId, schoolDocumentId, page, size);
         return ResponseEntity.ok(ApiResponse.of(response));
     }
 
@@ -161,10 +162,11 @@ public class DocumentController {
     public ResponseEntity<ApiResponse<PageResponse<DocumentSummaryResponse>>> searchDocuments(
             @RequestParam String keyword,
             @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) Long schoolDocumentId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments(keyword, categoryId, page, size);
+        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments(keyword, categoryId, schoolDocumentId, page, size);
         return ResponseEntity.ok(ApiResponse.of(response));
     }
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentCreateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentCreateRequest.java
@@ -29,6 +29,9 @@ public record DocumentCreateRequest(
         @NotNull(message = "카테고리 ID는 필수입니다.")
         Long categoryId,
 
+        @Schema(description = "학교 하위 문서가 속한 학교 문서 ID", example = "101", nullable = true)
+        Long schoolDocumentId,
+
         @Schema(description = "사건 발생 연도, 일반 문서는 비워둘 수 있는 필드", example = "1592", nullable = true)
         Integer eventYear,
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentUpdateRequest.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/request/DocumentUpdateRequest.java
@@ -24,6 +24,8 @@ public record DocumentUpdateRequest(
         @NotNull(message = "카테고리 ID는 필수입니다.")
         Long categoryId,
 
+        Long schoolDocumentId,
+
         Integer eventYear,
 
         @NotNull(message = "본문 JSON은 비어 있을 수 없습니다.")

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentCreateResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentCreateResponse.java
@@ -16,6 +16,10 @@ public record DocumentCreateResponse(
         Long categoryId,
         @Schema(description = "카테고리 이름", example = "역사")
         String categoryName,
+        @Schema(description = "연결된 학교 문서 ID", example = "101", nullable = true)
+        Long schoolDocumentId,
+        @Schema(description = "연결된 학교 문서 제목", example = "진주고등학교", nullable = true)
+        String schoolName,
         @Schema(description = "사건 발생 연도, 일반 문서는 null 가능", example = "1592", nullable = true)
         Integer eventYear,
         @Schema(description = "작성자 사용자 ID", example = "7")

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
@@ -16,6 +16,10 @@ public record DocumentDetailResponse(
         Long categoryId,
         @Schema(description = "카테고리 이름", example = "역사")
         String categoryName,
+        @Schema(description = "연결된 학교 문서 ID", example = "101", nullable = true)
+        Long schoolDocumentId,
+        @Schema(description = "연결된 학교 문서 제목", example = "진주고등학교", nullable = true)
+        String schoolName,
         @Schema(description = "사건 발생 연도, 일반 문서는 null 가능", example = "1592", nullable = true)
         Integer eventYear,
         @Schema(description = "작성자 사용자 ID", example = "7")

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentSummaryResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentSummaryResponse.java
@@ -15,6 +15,10 @@ public record DocumentSummaryResponse(
         Long categoryId,
         @Schema(description = "카테고리 이름", example = "역사")
         String categoryName,
+        @Schema(description = "연결된 학교 문서 ID", example = "101", nullable = true)
+        Long schoolDocumentId,
+        @Schema(description = "연결된 학교 문서 제목", example = "진주고등학교", nullable = true)
+        String schoolName,
         @Schema(description = "사건 발생 연도, 일반 문서는 null 가능", example = "1592", nullable = true)
         Integer eventYear,
         @Schema(description = "작성자 닉네임", example = "jinju-admin")

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
@@ -59,17 +59,31 @@ public class Document extends BaseEntity {
     @JoinColumn(name = "fk_category_id", nullable = false)
     private Category category;
 
+    // 학교 하위 문서가 어느 학교 문서에 속하는지 연결한다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_school_document_id")
+    private Document schoolDocument;
+
     public void increaseViewCount() {
         this.viewCount++;
     }
 
-    public void update(String title, String content, String summary, Integer eventYear, String contentJson, Category category) {
+    public void update(
+            String title,
+            String content,
+            String summary,
+            Integer eventYear,
+            String contentJson,
+            Category category,
+            Document schoolDocument
+    ) {
         this.title = title;
         this.content = content;
         this.summary = summary;
         this.eventYear = eventYear;
         this.contentJson = contentJson;
         this.category = category;
+        this.schoolDocument = schoolDocument;
     }
 
     public boolean isWrittenBy(Long userId) {

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentCreateResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentCreateResponseMapper.java
@@ -16,6 +16,8 @@ public class DocumentCreateResponseMapper {
                 document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getId(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getTitle(),
                 document.getEventYear(),
                 document.getAuthor().getId(),
                 document.getAuthor().getNickname(),

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
@@ -16,6 +16,8 @@ public class DocumentDetailResponseMapper {
                 document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getId(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getTitle(),
                 document.getEventYear(),
                 document.getAuthor().getId(),
                 document.getAuthor().getNickname(),

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentSummaryResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentSummaryResponseMapper.java
@@ -15,6 +15,8 @@ public class DocumentSummaryResponseMapper {
                 document.getSummary(),
                 document.getCategory().getId(),
                 document.getCategory().getName(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getId(),
+                document.getSchoolDocument() == null ? null : document.getSchoolDocument().getTitle(),
                 document.getEventYear(),
                 document.getAuthor().getNickname(),
                 document.getViewCount(),

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -1,6 +1,7 @@
 package com.jinju.jinjuwiki.domain.document.repository;
 
 import com.jinju.jinjuwiki.domain.document.entity.Document;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,14 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     Page<Document> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<Document> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
+
+    Page<Document> findBySchoolDocumentIdOrderByCreatedAtDesc(Long schoolDocumentId, Pageable pageable);
+
+    Page<Document> findByCategoryIdAndSchoolDocumentIdOrderByCreatedAtDesc(Long categoryId, Long schoolDocumentId, Pageable pageable);
+
+    List<Document> findByCategoryIdOrderByTitleAsc(Long categoryId);
+
+    boolean existsBySchoolDocumentId(Long schoolDocumentId);
 
     // 조회수 원자 증가 쿼리
     @Modifying(flushAutomatically = true)
@@ -59,6 +68,40 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             """)
     Page<Document> searchByCategoryAndKeyword(
             @Param("categoryId") Long categoryId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    @Query("""
+            select d
+            from Document d
+            where d.schoolDocument.id = :schoolDocumentId
+              and (
+                  lower(d.title) like lower(concat('%', :keyword, '%'))
+                or lower(d.summary) like lower(concat('%', :keyword, '%'))
+              )
+            order by d.createdAt desc
+            """)
+    Page<Document> searchBySchoolAndKeyword(
+            @Param("schoolDocumentId") Long schoolDocumentId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    @Query("""
+            select d
+            from Document d
+            where d.category.id = :categoryId
+              and d.schoolDocument.id = :schoolDocumentId
+              and (
+                  lower(d.title) like lower(concat('%', :keyword, '%'))
+                or lower(d.summary) like lower(concat('%', :keyword, '%'))
+              )
+            order by d.createdAt desc
+            """)
+    Page<Document> searchByCategoryAndSchoolAndKeyword(
+            @Param("categoryId") Long categoryId,
+            @Param("schoolDocumentId") Long schoolDocumentId,
             @Param("keyword") String keyword,
             Pageable pageable
     );

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentService.java
@@ -13,9 +13,9 @@ public interface DocumentService {
 
     DocumentDetailResponse getDocument(Long id, Long viewerUserId, String viewerIp);
 
-    PageResponse<DocumentSummaryResponse> getDocuments(Long categoryId, int page, int size);
+    PageResponse<DocumentSummaryResponse> getDocuments(Long categoryId, Long schoolDocumentId, int page, int size);
 
-    PageResponse<DocumentSummaryResponse> searchDocuments(String keyword, Long categoryId, int page, int size);
+    PageResponse<DocumentSummaryResponse> searchDocuments(String keyword, Long categoryId, Long schoolDocumentId, int page, int size);
 
     DocumentDetailResponse updateDocument(Long id, DocumentUpdateRequest request, Long currentUserId);
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.jinju.jinjuwiki.domain.document.service;
 
 import com.jinju.jinjuwiki.domain.category.entity.Category;
+import com.jinju.jinjuwiki.domain.category.entity.CategoryType;
 import com.jinju.jinjuwiki.domain.category.repository.CategoryRepository;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentCreateRequest;
 import com.jinju.jinjuwiki.domain.document.dto.request.DocumentUpdateRequest;
@@ -20,6 +21,7 @@ import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
 import com.jinju.jinjuwiki.global.response.PageResponse;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +32,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DocumentServiceImpl implements DocumentService {
+
+    private static final Set<String> SCHOOL_CHILD_CATEGORY_NAMES = Set.of(
+            CategoryType.STUDENT.getDisplayName(),
+            CategoryType.TEACHER.getDisplayName(),
+            CategoryType.INCIDENT.getDisplayName()
+    );
 
     private final DocumentRepository documentRepository;
     private final UserRepository userRepository;
@@ -46,6 +54,7 @@ public class DocumentServiceImpl implements DocumentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         Category category = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+        Document schoolDocument = resolveSchoolDocument(category, request.schoolDocumentId());
 
         Document document = Document.builder()
                 .title(request.title())
@@ -55,6 +64,7 @@ public class DocumentServiceImpl implements DocumentService {
                 .contentJson(DocumentContentJsonCodec.writeValue(request.contentJson()))
                 .author(author)
                 .category(category)
+                .schoolDocument(schoolDocument)
                 .build();
 
         Document savedDocument = documentRepository.save(document);
@@ -76,18 +86,37 @@ public class DocumentServiceImpl implements DocumentService {
     @Override
     @Transactional(readOnly = true)
     // 문서 목록 응답 조립 메서드
-    public PageResponse<DocumentSummaryResponse> getDocuments(Long categoryId, int page, int size) {
+    public PageResponse<DocumentSummaryResponse> getDocuments(Long categoryId, Long schoolDocumentId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Document> documents = categoryId == null
-                ? documentRepository.findAllByOrderByCreatedAtDesc(pageable)
-                : documentRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+        Page<Document> documents;
+
+        if (categoryId != null && schoolDocumentId != null) {
+            documents = documentRepository.findByCategoryIdAndSchoolDocumentIdOrderByCreatedAtDesc(
+                    categoryId,
+                    schoolDocumentId,
+                    pageable
+            );
+        } else if (categoryId != null) {
+            documents = documentRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+        } else if (schoolDocumentId != null) {
+            documents = documentRepository.findBySchoolDocumentIdOrderByCreatedAtDesc(schoolDocumentId, pageable);
+        } else {
+            documents = documentRepository.findAllByOrderByCreatedAtDesc(pageable);
+        }
+
         return PageResponse.from(documents.map(DocumentSummaryResponseMapper::toResponse));
     }
 
     @Override
     @Transactional(readOnly = true)
     // 문서 검색 응답 조립 메서드
-    public PageResponse<DocumentSummaryResponse> searchDocuments(String keyword, Long categoryId, int page, int size) {
+    public PageResponse<DocumentSummaryResponse> searchDocuments(
+            String keyword,
+            Long categoryId,
+            Long schoolDocumentId,
+            int page,
+            int size
+    ) {
         Pageable pageable = PageRequest.of(page, size);
         String normalizedKeyword = keyword == null ? "" : keyword.trim();
 
@@ -95,9 +124,23 @@ public class DocumentServiceImpl implements DocumentService {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 
-        Page<Document> documents = categoryId == null
-                ? documentRepository.searchByKeyword(normalizedKeyword, pageable)
-                : documentRepository.searchByCategoryAndKeyword(categoryId, normalizedKeyword, pageable);
+        Page<Document> documents;
+
+        if (categoryId != null && schoolDocumentId != null) {
+            documents = documentRepository.searchByCategoryAndSchoolAndKeyword(
+                    categoryId,
+                    schoolDocumentId,
+                    normalizedKeyword,
+                    pageable
+            );
+        } else if (categoryId != null) {
+            documents = documentRepository.searchByCategoryAndKeyword(categoryId, normalizedKeyword, pageable);
+        } else if (schoolDocumentId != null) {
+            documents = documentRepository.searchBySchoolAndKeyword(schoolDocumentId, normalizedKeyword, pageable);
+        } else {
+            documents = documentRepository.searchByKeyword(normalizedKeyword, pageable);
+        }
+
         return PageResponse.from(documents.map(DocumentSummaryResponseMapper::toResponse));
     }
 
@@ -110,6 +153,7 @@ public class DocumentServiceImpl implements DocumentService {
 
         Category category = categoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+        Document schoolDocument = resolveSchoolDocument(category, request.schoolDocumentId());
 
         document.update(
                 request.title(),
@@ -117,7 +161,8 @@ public class DocumentServiceImpl implements DocumentService {
                 request.summary(),
                 request.eventYear(),
                 DocumentContentJsonCodec.writeValue(request.contentJson()),
-                category
+                category,
+                schoolDocument
         );
         return DocumentDetailResponseMapper.toResponse(document);
     }
@@ -127,7 +172,43 @@ public class DocumentServiceImpl implements DocumentService {
     public void deleteDocument(Long id, Long currentUserId) {
         Document document = documentDomainService.getDocument(id);
         documentDomainService.validateAuthor(document, currentUserId);
+
+        if (isSchoolCategory(document.getCategory()) && documentRepository.existsBySchoolDocumentId(document.getId())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
         documentRepository.delete(document);
+    }
+
+    private Document resolveSchoolDocument(Category category, Long schoolDocumentId) {
+        if (isSchoolChildCategory(category)) {
+            if (schoolDocumentId == null) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+
+            Document schoolDocument = documentRepository.findById(schoolDocumentId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND));
+
+            if (!isSchoolCategory(schoolDocument.getCategory())) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+
+            return schoolDocument;
+        }
+
+        if (schoolDocumentId != null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        return null;
+    }
+
+    private boolean isSchoolCategory(Category category) {
+        return CategoryType.SCHOOL.getDisplayName().equals(category.getName());
+    }
+
+    private boolean isSchoolChildCategory(Category category) {
+        return SCHOOL_CHILD_CATEGORY_NAMES.contains(category.getName());
     }
 
     // 문서 조회 사용자 식별 분기 메서드

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -80,6 +80,7 @@ class DocumentServiceTest {
                 "문서 제목",
                 "문서 요약",
                 10L,
+                null,
                 2024,
                 contentJson
         );
@@ -119,6 +120,7 @@ class DocumentServiceTest {
                 "문서 제목",
                 "문서 요약",
                 10L,
+                null,
                 2024,
                 createContentJson()
         );
@@ -192,7 +194,7 @@ class DocumentServiceTest {
                 .thenReturn(pageResponse);
 
         // when
-        PageResponse<DocumentSummaryResponse> response = documentService.getDocuments(30L, 0, 10);
+        PageResponse<DocumentSummaryResponse> response = documentService.getDocuments(30L, null, 0, 10);
 
         // then
         assertThat(response.content()).hasSize(2);
@@ -209,15 +211,17 @@ class DocumentServiceTest {
         Category category = createCategory(40L, "학교");
         Category updatedCategory = createCategory(41L, "선생님");
         Document document = createDocument(400L, "원래 제목", "원래 요약", 2023, author, category);
+        Document schoolDocument = createDocument(401L, "진주고등학교", "학교 요약", 2024, author, category);
         JsonNode updatedContentJson = createContentJson();
         when(documentDomainService.getDocument(400L)).thenReturn(document);
         doNothing().when(documentDomainService).validateAuthor(document, 4L);
         when(categoryRepository.findById(41L)).thenReturn(Optional.of(updatedCategory));
+        when(documentRepository.findById(401L)).thenReturn(Optional.of(schoolDocument));
 
         // when
         DocumentDetailResponse response = documentService.updateDocument(
                 400L,
-                new DocumentUpdateRequest("수정 제목", "수정 요약", 41L, 2024, updatedContentJson),
+                new DocumentUpdateRequest("수정 제목", "수정 요약", 41L, 401L, 2024, updatedContentJson),
                 4L
         );
 
@@ -227,9 +231,12 @@ class DocumentServiceTest {
         assertThat(response.eventYear()).isEqualTo(2024);
         assertThat(response.contentJson()).isEqualTo(updatedContentJson);
         assertThat(response.categoryName()).isEqualTo("선생님");
+        assertThat(response.schoolDocumentId()).isEqualTo(401L);
+        assertThat(response.schoolName()).isEqualTo("진주고등학교");
         verify(documentDomainService).getDocument(400L);
         verify(documentDomainService).validateAuthor(document, 4L);
         verify(categoryRepository).findById(41L);
+        verify(documentRepository).findById(401L);
     }
 
     @Test
@@ -254,7 +261,7 @@ class DocumentServiceTest {
                 BusinessException.class,
                 () -> documentService.updateDocument(
                         500L,
-                        new DocumentUpdateRequest("수정 제목", "수정 요약", 50L, 2024, createContentJson()),
+                        new DocumentUpdateRequest("수정 제목", "수정 요약", 50L, null, 2024, createContentJson()),
                         6L
                 )
         );
@@ -334,7 +341,7 @@ class DocumentServiceTest {
         when(documentRepository.searchByKeyword(eq("공부"), any(Pageable.class))).thenReturn(searchResult);
 
         // when
-        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments("공부", null, 0, 10);
+        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments("공부", null, null, 0, 10);
 
         // then
         assertThat(response.content()).hasSize(1);
@@ -359,7 +366,7 @@ class DocumentServiceTest {
                 .thenReturn(searchResult);
 
         // when
-        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments("시험", 110L, 0, 10);
+        PageResponse<DocumentSummaryResponse> response = documentService.searchDocuments("시험", 110L, null, 0, 10);
 
         // then
         assertThat(response.content()).hasSize(1);
@@ -376,10 +383,29 @@ class DocumentServiceTest {
         // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
-                () -> documentService.searchDocuments(keyword, null, 0, 10)
+                () -> documentService.searchDocuments(keyword, null, null, 0, 10)
         );
 
         // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("학교 하위 카테고리 문서는 학교 문서 ID가 필요하다.")
+    void createDocumentFailWhenSchoolDocumentIdMissing() {
+        User author = createUser(12L, "doc12@test.com", "docUser12");
+        Category category = createCategory(120L, "학생");
+        when(userRepository.findById(12L)).thenReturn(Optional.of(author));
+        when(categoryRepository.findById(120L)).thenReturn(Optional.of(category));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> documentService.createDocument(
+                        new DocumentCreateRequest("학생 문서", "요약", 120L, null, 2024, createContentJson()),
+                        12L
+                )
+        );
+
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT);
     }
 
@@ -422,6 +448,7 @@ class DocumentServiceTest {
                 .contentJson(DocumentContentJsonCodec.writeValue(createContentJson()))
                 .author(author)
                 .category(category)
+                .schoolDocument(null)
                 .build();
         ReflectionTestUtils.setField(document, "id", id);
         return document;


### PR DESCRIPTION
## 작업 내용
- 카테고리=학교 문서 목록을 읽어 각 학교 문서를 상위 노드로 만들고, 자식으로 학생/선생님/사건사고를 붙이도록 변경
- 문서 응답에도 schoolDocumentId, schoolName을 포함해 클라이언트가 현재 소속 학교를 알 수 있게 함

## 변경 이유
- 클라이언트 단의 요청

## 관련 이슈
- 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [ ] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
