### PR TITLE
fix : Redis 장애 시 문서 조회 API 실패 전파 차단

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -23,6 +23,7 @@ import com.jinju.jinjuwiki.global.error.ErrorCode;
 import com.jinju.jinjuwiki.global.response.PageResponse;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DocumentServiceImpl implements DocumentService {
 
@@ -236,7 +238,12 @@ public class DocumentServiceImpl implements DocumentService {
 
     // 조회수 Redis 누적 반영 메서드
     private void bufferDocumentViewCount(Document document) {
-        redisDocumentViewCountBuffer.increment(document.getId());
-        document.increaseViewCount();
+        try {
+            redisDocumentViewCountBuffer.increment(document.getId());
+            document.increaseViewCount();
+        } catch (RuntimeException exception) {
+            // Redis 장애가 발생해도 문서 본문 조회는 성공시킨다.
+            log.warn("문서 조회수 버퍼 반영 실패, documentId={}", document.getId(), exception);
+        }
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceImpl.java
@@ -2,11 +2,13 @@ package com.jinju.jinjuwiki.domain.search.service;
 
 import com.jinju.jinjuwiki.domain.document.entity.Document;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 // 문서 조회 로그 저장 서비스 구현체
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class DocumentViewLogServiceImpl implements DocumentViewLogService {
 
@@ -20,8 +22,7 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
             return false;
         }
 
-        // 급상승 집계 Redis 반영 호출
-        redisTrendingDocumentViewBuffer.incrementCurrentHourScore(document.getId());
+        recordTrendingDocumentView(document);
         return true;
     }
 
@@ -42,5 +43,15 @@ public class DocumentViewLogServiceImpl implements DocumentViewLogService {
     // 비로그인 조회 IP 공백 여부 확인 메서드
     private boolean isBlankIp(String viewerIp) {
         return viewerIp == null || viewerIp.isBlank();
+    }
+
+    // 급상승 집계 Redis 반영 메서드
+    private void recordTrendingDocumentView(Document document) {
+        try {
+            redisTrendingDocumentViewBuffer.incrementCurrentHourScore(document.getId());
+        } catch (RuntimeException exception) {
+            // 급상승 집계 실패가 문서 조회 성공을 막지 않도록 한다.
+            log.warn("급상승 문서 집계 반영 실패, documentId={}", document.getId(), exception);
+        }
     }
 }

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -169,6 +169,36 @@ class DocumentServiceTest {
     }
 
     @Test
+    @DisplayName("조회수 버퍼 반영이 실패해도 문서 상세 조회는 성공한다.")
+    void getDocumentSuccessWhenViewCountBufferFails() {
+        // given
+        Document document = Document.builder()
+                .title("수학 공부법")
+                .content(DocumentContentJsonCodec.writeValue(createContentJson()))
+                .summary("시험 대비 요약")
+                .eventYear(2024)
+                .contentJson(DocumentContentJsonCodec.writeValue(createContentJson()))
+                .author(createUser(2L, "doc2@test.com", "docUser2"))
+                .category(createCategory(20L, "학생"))
+                .build();
+        ReflectionTestUtils.setField(document, "id", 200L);
+
+        when(documentDomainService.getDocument(200L)).thenReturn(document);
+        when(documentViewLogService.save(document, 2L, null)).thenReturn(true);
+        when(redisDocumentViewCountBuffer.increment(200L)).thenThrow(new IllegalStateException("redis unavailable"));
+
+        // when
+        DocumentDetailResponse response = documentService.getDocument(200L, 2L, "127.0.0.1");
+
+        // then
+        assertThat(response.documentId()).isEqualTo(200L);
+        assertThat(response.viewCount()).isEqualTo(0L);
+        verify(documentDomainService).getDocument(200L);
+        verify(documentViewLogService).save(document, 2L, null);
+        verify(redisDocumentViewCountBuffer).increment(200L);
+    }
+
+    @Test
     @DisplayName("문서 목록은 최신순으로 페이지 조회할 수 있다.")
     void getDocumentsSuccess() {
         // given

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/service/DocumentViewLogServiceTest.java
@@ -1,5 +1,6 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -101,6 +102,24 @@ class DocumentViewLogServiceTest {
         documentViewLogService.save(document, 2L, null);
 
         // then
+        verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
+        verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
+    }
+
+    @Test
+    @DisplayName("급상승 집계 Redis 장애가 발생해도 문서 조회 로그 저장은 성공 처리한다.")
+    void saveViewLogSuccessWhenTrendingBufferFails() {
+        // given
+        Document document = createDocument(1L, "급상승 문서");
+        when(redisDocumentViewLimiter.isAllowed(1L, 2L, null)).thenReturn(true);
+        when(redisTrendingDocumentViewBuffer.incrementCurrentHourScore(1L))
+                .thenThrow(new RuntimeException("redis unavailable"));
+
+        // when
+        boolean saved = documentViewLogService.save(document, 2L, null);
+
+        // then
+        assertThat(saved).isTrue();
         verify(redisDocumentViewLimiter).isAllowed(1L, 2L, null);
         verify(redisTrendingDocumentViewBuffer).incrementCurrentHourScore(1L);
     }


### PR DESCRIPTION
## 작업 내용
- Redis 장애가 문서 조회 API를 죽이지 않도록 하는 안정화

## 변경 이유
- 배포 

## 관련 이슈
- 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [ ] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
