### PR TITLE
fix : 문서 조회수 응답값과 영속화 경로 분리

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/mapper/DocumentDetailResponseMapper.java
@@ -10,6 +10,11 @@ public class DocumentDetailResponseMapper {
 
     // 문서 엔티티를 상세 응답 DTO로 변환
     public static DocumentDetailResponse toResponse(Document document) {
+        return toResponse(document, document.getViewCount());
+    }
+
+    // 문서 엔티티를 상세 응답 DTO로 변환
+    public static DocumentDetailResponse toResponse(Document document, long viewCount) {
         return new DocumentDetailResponse(
                 document.getId(),
                 document.getTitle(),
@@ -22,7 +27,7 @@ public class DocumentDetailResponseMapper {
                 document.getAuthor().getId(),
                 document.getAuthor().getNickname(),
                 DocumentContentJsonCodec.readTree(document.getContentJson() == null ? document.getContent() : document.getContentJson()),
-                document.getViewCount(),
+                viewCount,
                 document.getCreatedAt(),
                 document.getUpdatedAt()
         );

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -78,11 +78,13 @@ public class DocumentServiceImpl implements DocumentService {
     // 문서 상세 응답 조립 메서드
     public DocumentDetailResponse getDocument(Long id, Long viewerUserId, String viewerIp) {
         Document document = documentDomainService.getDocument(id);
+        long responseViewCount = document.getViewCount();
 
         if (recordDocumentView(document, viewerUserId, viewerIp)) {
+            responseViewCount++;
             bufferDocumentViewCount(document);
         }
-        return DocumentDetailResponseMapper.toResponse(document);
+        return DocumentDetailResponseMapper.toResponse(document, responseViewCount);
     }
 
     @Override
@@ -240,7 +242,6 @@ public class DocumentServiceImpl implements DocumentService {
     private void bufferDocumentViewCount(Document document) {
         try {
             redisDocumentViewCountBuffer.increment(document.getId());
-            document.increaseViewCount();
         } catch (RuntimeException exception) {
             // Redis 장애가 발생해도 문서 본문 조회는 성공시킨다.
             log.warn("문서 조회수 버퍼 반영 실패, documentId={}", document.getId(), exception);

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -192,7 +192,7 @@ class DocumentServiceTest {
 
         // then
         assertThat(response.documentId()).isEqualTo(200L);
-        assertThat(response.viewCount()).isEqualTo(0L);
+        assertThat(response.viewCount()).isEqualTo(1L);
         verify(documentDomainService).getDocument(200L);
         verify(documentViewLogService).save(document, 2L, null);
         verify(redisDocumentViewCountBuffer).increment(200L);


### PR DESCRIPTION
## 작업 내용
- 문서 상세 조회 응답 viewCount 계산 방식 변경
- 상세 응답 mapper 확장

## 변경 이유
- 배포

## 관련 이슈
- 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [ ] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
