### PR TITLE
fix : 문서 상세 조회수 응답을 집계 완료 기준으로 통일

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/dto/response/DocumentDetailResponse.java
@@ -31,7 +31,7 @@ public record DocumentDetailResponse(
                 example = "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"진주성 전투 본문\"}]}]}"
         )
         JsonNode contentJson,
-        @Schema(description = "문서 조회수", example = "128")
+        @Schema(description = "문서 조회수. Redis 버퍼 반영 예정값이 아닌 집계 완료 기준 값", example = "128")
         Long viewCount,
         @Schema(description = "문서 생성 시각", example = "2026-04-14T10:30:00")
         LocalDateTime createdAt,

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -83,7 +83,7 @@ public class DocumentServiceImpl implements DocumentService {
             bufferDocumentViewCount(document);
         }
 
-        // 응답 조회수는 Redis 버퍼 반영 예정값이 아니라 현재 영속 상태의 집계값만 노출한다.
+        // 응답 조회수는 Redis 버퍼 반영 예정값이 아니라 현재 영속 상태의 집계값만 노출
         return DocumentDetailResponseMapper.toResponse(document);
     }
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceImpl.java
@@ -78,13 +78,13 @@ public class DocumentServiceImpl implements DocumentService {
     // 문서 상세 응답 조립 메서드
     public DocumentDetailResponse getDocument(Long id, Long viewerUserId, String viewerIp) {
         Document document = documentDomainService.getDocument(id);
-        long responseViewCount = document.getViewCount();
 
         if (recordDocumentView(document, viewerUserId, viewerIp)) {
-            responseViewCount++;
             bufferDocumentViewCount(document);
         }
-        return DocumentDetailResponseMapper.toResponse(document, responseViewCount);
+
+        // 응답 조회수는 Redis 버퍼 반영 예정값이 아니라 현재 영속 상태의 집계값만 노출한다.
+        return DocumentDetailResponseMapper.toResponse(document);
     }
 
     @Override
@@ -243,7 +243,7 @@ public class DocumentServiceImpl implements DocumentService {
         try {
             redisDocumentViewCountBuffer.increment(document.getId());
         } catch (RuntimeException exception) {
-            // Redis 장애가 발생해도 문서 본문 조회는 성공시킨다.
+            // Redis 장애가 발생해도 문서 본문 조회는 성공 처리
             log.warn("문서 조회수 버퍼 반영 실패, documentId={}", document.getId(), exception);
         }
     }

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/service/DocumentServiceTest.java
@@ -138,7 +138,7 @@ class DocumentServiceTest {
     }
 
     @Test
-    @DisplayName("문서를 조회하면 조회수가 증가한다.")
+    @DisplayName("문서를 조회하면 응답 조회수는 현재 집계값을 유지하고 버퍼만 반영한다.")
     void getDocumentSuccess() {
         // given
         Document document = Document.builder()
@@ -161,7 +161,7 @@ class DocumentServiceTest {
 
         // then
         assertThat(response.documentId()).isEqualTo(200L);
-        assertThat(response.viewCount()).isEqualTo(1L);
+        assertThat(response.viewCount()).isEqualTo(0L);
         assertThat(response.title()).isEqualTo("수학 공부법");
         verify(documentDomainService).getDocument(200L);
         verify(documentViewLogService).save(document, 2L, null);
@@ -169,7 +169,7 @@ class DocumentServiceTest {
     }
 
     @Test
-    @DisplayName("조회수 버퍼 반영이 실패해도 문서 상세 조회는 성공한다.")
+    @DisplayName("조회수 버퍼 반영이 실패해도 응답 조회수는 현재 집계값으로 유지된다.")
     void getDocumentSuccessWhenViewCountBufferFails() {
         // given
         Document document = Document.builder()
@@ -192,7 +192,7 @@ class DocumentServiceTest {
 
         // then
         assertThat(response.documentId()).isEqualTo(200L);
-        assertThat(response.viewCount()).isEqualTo(1L);
+        assertThat(response.viewCount()).isEqualTo(0L);
         verify(documentDomainService).getDocument(200L);
         verify(documentViewLogService).save(document, 2L, null);
         verify(redisDocumentViewCountBuffer).increment(200L);


### PR DESCRIPTION
## 작업 내용
- getDocument()에서 responseViewCount++ 선반영 로직을 제거

## 변경 이유
- 현재 영속 상태의 집계값만 반환하게 하기 위해

## 관련 이슈
- #107 

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
