### PR TITLE
fix : password reset token 단건 조회를 위한 unique 제약 추가

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/entity/PasswordResetToken.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/entity/PasswordResetToken.java
@@ -33,7 +33,7 @@ public class PasswordResetToken extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiresAt;
 
-    @Column(length = 100)
+    @Column(unique = true, length = 100)
     private String resetToken;
 
     @Column

--- a/src/main/resources/db/migration/V3__add_password_reset_token_unique_constraint.sql
+++ b/src/main/resources/db/migration/V3__add_password_reset_token_unique_constraint.sql
@@ -1,0 +1,2 @@
+alter table password_reset_tokens
+    add constraint uk_password_reset_tokens_reset_token unique (reset_token);


### PR DESCRIPTION
## 작업 내용
- reset_token 단건 조회 전제를 DB 제약으로 올림
- 기존 migration은 유지하고, 새 migration V3로 unique 제약을 추가

## 변경 이유
- 

## 관련 이슈
- #105 

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
