### PR TITLE
refactor : Redis rate limiter 공통 카운터 처리 추출

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisEmailVerificationSendRateLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisEmailVerificationSendRateLimiter.java
@@ -2,12 +2,10 @@ package com.jinju.jinjuwiki.domain.auth.service;
 
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // 이메일 인증 발송 요청 제한 Redis 클래스
@@ -16,9 +14,8 @@ import org.springframework.stereotype.Component;
 public class RedisEmailVerificationSendRateLimiter {
 
     private static final String SEND_LIMIT_KEY_PREFIX = "auth:email-send";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     @Value("${app.auth.email-verification-send-rate-limit.count:3}")
     private long sendLimitCount;
@@ -28,11 +25,7 @@ public class RedisEmailVerificationSendRateLimiter {
 
     // 이메일 인증 발송 요청 제한 확인 메서드
     public void validateAllowed(String email) {
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(createRedisKey(email)),
-                String.valueOf(getSendLimitWindow().toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(createRedisKey(email), getSendLimitWindow());
 
         if (currentCount == null || currentCount > sendLimitCount) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
@@ -47,19 +40,5 @@ public class RedisEmailVerificationSendRateLimiter {
     // 이메일 인증 발송 제한 시간 계산 메서드
     private Duration getSendLimitWindow() {
         return Duration.ofSeconds(sendLimitWindowSeconds);
-    }
-
-    // TTL 포함 증가 Lua 스크립트 생성 메서드
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisEmailVerificationVerifyAttemptLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisEmailVerificationVerifyAttemptLimiter.java
@@ -2,12 +2,10 @@ package com.jinju.jinjuwiki.domain.auth.service;
 
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // 이메일 인증코드 검증 실패 제한 Redis 클래스
@@ -16,9 +14,8 @@ import org.springframework.stereotype.Component;
 public class RedisEmailVerificationVerifyAttemptLimiter {
 
     private static final String VERIFY_FAILURE_KEY_PREFIX = "auth:email-verify-failure";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     @Value("${app.auth.email-verification-verify-attempt-limit.count:5}")
     private long verifyFailureLimitCount;
@@ -28,7 +25,7 @@ public class RedisEmailVerificationVerifyAttemptLimiter {
 
     // 이메일 인증코드 검증 가능 여부 확인 메서드
     public void validateAllowed(String email) {
-        String failureCount = stringRedisTemplate.opsForValue().get(createRedisKey(email));
+        String failureCount = redisCounterSupport.get(createRedisKey(email));
         if (failureCount == null) {
             return;
         }
@@ -40,11 +37,7 @@ public class RedisEmailVerificationVerifyAttemptLimiter {
 
     // 이메일 인증코드 검증 실패 누적 메서드
     public long recordFailure(String email) {
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(createRedisKey(email)),
-                String.valueOf(getVerifyFailureWindow().toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(createRedisKey(email), getVerifyFailureWindow());
 
         if (currentCount == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
@@ -55,7 +48,7 @@ public class RedisEmailVerificationVerifyAttemptLimiter {
 
     // 이메일 인증코드 검증 실패 초기화 메서드
     public void reset(String email) {
-        stringRedisTemplate.delete(createRedisKey(email));
+        redisCounterSupport.delete(createRedisKey(email));
     }
 
     // 검증 실패 Redis 키 생성 메서드
@@ -66,19 +59,5 @@ public class RedisEmailVerificationVerifyAttemptLimiter {
     // 이메일 인증코드 검증 실패 제한 시간 계산 메서드
     private Duration getVerifyFailureWindow() {
         return Duration.ofSeconds(verifyFailureWindowSeconds);
-    }
-
-    // TTL 포함 증가 Lua 스크립트 생성 메서드
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisLoginAttemptLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisLoginAttemptLimiter.java
@@ -1,11 +1,9 @@
 package com.jinju.jinjuwiki.domain.auth.service;
 
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // 로그인 실패 제한 Redis 클래스
@@ -14,9 +12,8 @@ import org.springframework.stereotype.Component;
 public class RedisLoginAttemptLimiter {
 
     private static final String LOGIN_FAILURE_KEY_PREFIX = "auth:login-failure";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     @Value("${app.auth.login-attempt-limit.count:5}")
     private long loginFailureLimitCount;
@@ -26,7 +23,7 @@ public class RedisLoginAttemptLimiter {
 
     // 로그인 가능 여부 확인 메서드
     public boolean isAllowed(String email) {
-        String failureCount = stringRedisTemplate.opsForValue().get(createRedisKey(email));
+        String failureCount = redisCounterSupport.get(createRedisKey(email));
         if (failureCount == null) {
             return true;
         }
@@ -36,11 +33,7 @@ public class RedisLoginAttemptLimiter {
 
     // 로그인 실패 누적 메서드
     public long recordFailure(String email) {
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(createRedisKey(email)),
-                String.valueOf(getLoginFailureWindow().toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(createRedisKey(email), getLoginFailureWindow());
 
         if (currentCount == null) {
             throw new IllegalStateException("로그인 실패 횟수 누적에 실패했습니다.");
@@ -51,7 +44,7 @@ public class RedisLoginAttemptLimiter {
 
     // 로그인 실패 초기화 메서드
     public void reset(String email) {
-        stringRedisTemplate.delete(createRedisKey(email));
+        redisCounterSupport.delete(createRedisKey(email));
     }
 
     private String createRedisKey(String email) {
@@ -65,18 +58,5 @@ public class RedisLoginAttemptLimiter {
     // 로그인 실패 제한 도달 여부 확인 메서드
     public boolean hasReachedLimit(long failureCount) {
         return failureCount >= loginFailureLimitCount;
-    }
-
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisPasswordResetRequestRateLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisPasswordResetRequestRateLimiter.java
@@ -2,12 +2,10 @@ package com.jinju.jinjuwiki.domain.auth.service;
 
 import com.jinju.jinjuwiki.global.error.BusinessException;
 import com.jinju.jinjuwiki.global.error.ErrorCode;
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // 비밀번호 재설정 요청 제한 Redis 클래스
@@ -16,9 +14,8 @@ import org.springframework.stereotype.Component;
 public class RedisPasswordResetRequestRateLimiter {
 
     private static final String RESET_LIMIT_KEY_PREFIX = "auth:password-reset";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     @Value("${app.auth.password-reset-request-rate-limit.count:5}")
     private long resetLimitCount;
@@ -28,11 +25,7 @@ public class RedisPasswordResetRequestRateLimiter {
 
     // 비밀번호 재설정 요청 제한 확인 메서드
     public void validateAllowed(String email) {
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(createRedisKey(email)),
-                String.valueOf(getResetLimitWindow().toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(createRedisKey(email), getResetLimitWindow());
 
         if (currentCount == null || currentCount > resetLimitCount) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
@@ -47,19 +40,5 @@ public class RedisPasswordResetRequestRateLimiter {
     // 비밀번호 재설정 요청 제한 시간 계산 메서드
     private Duration getResetLimitWindow() {
         return Duration.ofSeconds(resetLimitWindowSeconds);
-    }
-
-    // TTL 포함 증가 Lua 스크립트 생성 메서드
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisPasswordResetVerifyAttemptLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/auth/service/RedisPasswordResetVerifyAttemptLimiter.java
@@ -1,11 +1,9 @@
 package com.jinju.jinjuwiki.domain.auth.service;
 
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // 비밀번호 재설정 인증코드 확인 실패 제한 Redis 클래스
@@ -14,9 +12,8 @@ import org.springframework.stereotype.Component;
 public class RedisPasswordResetVerifyAttemptLimiter {
 
     private static final String PASSWORD_RESET_VERIFY_FAILURE_KEY_PREFIX = "auth:password-reset-verify-failure";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     @Value("${app.auth.password-reset-verify-attempt-limit.count:5}")
     private long verifyFailureLimitCount;
@@ -26,7 +23,7 @@ public class RedisPasswordResetVerifyAttemptLimiter {
 
     // 비밀번호 재설정 인증코드 확인 가능 여부 메서드
     public boolean isAllowed(String email) {
-        String failureCount = stringRedisTemplate.opsForValue().get(createRedisKey(email));
+        String failureCount = redisCounterSupport.get(createRedisKey(email));
         if (failureCount == null) {
             return true;
         }
@@ -36,11 +33,7 @@ public class RedisPasswordResetVerifyAttemptLimiter {
 
     // 비밀번호 재설정 인증코드 확인 실패 누적 메서드
     public long recordFailure(String email) {
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(createRedisKey(email)),
-                String.valueOf(getVerifyFailureWindow().toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(createRedisKey(email), getVerifyFailureWindow());
 
         if (currentCount == null) {
             throw new IllegalStateException("비밀번호 재설정 인증코드 실패 횟수 누적에 실패했습니다.");
@@ -51,7 +44,7 @@ public class RedisPasswordResetVerifyAttemptLimiter {
 
     // 비밀번호 재설정 인증코드 확인 실패 초기화 메서드
     public void reset(String email) {
-        stringRedisTemplate.delete(createRedisKey(email));
+        redisCounterSupport.delete(createRedisKey(email));
     }
 
     private String createRedisKey(String email) {
@@ -65,18 +58,5 @@ public class RedisPasswordResetVerifyAttemptLimiter {
     // 비밀번호 재설정 인증코드 확인 실패 제한 도달 여부 확인 메서드
     public boolean hasReachedLimit(long failureCount) {
         return failureCount >= verifyFailureLimitCount;
-    }
-
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewLimiter.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/search/service/RedisDocumentViewLimiter.java
@@ -1,10 +1,8 @@
 package com.jinju.jinjuwiki.domain.search.service;
 
+import com.jinju.jinjuwiki.global.config.RedisCounterSupport;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 // Redis 기반 문서 조회 제한기 클래스
@@ -15,18 +13,13 @@ public class RedisDocumentViewLimiter {
     private static final long VIEW_LIMIT_PER_HOUR = 3L;
     private static final Duration VIEW_WINDOW = Duration.ofHours(1);
     private static final String VIEW_LIMIT_KEY_PREFIX = "document:view-limit";
-    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisCounterSupport redisCounterSupport;
 
     // 조회 허용 여부 확인 메서드
     public boolean isAllowed(Long documentId, Long viewerUserId, String viewerIp) {
         String redisKey = createRedisKey(documentId, viewerUserId, viewerIp);
-        Long currentCount = stringRedisTemplate.execute(
-                INCREMENT_WITH_TTL_SCRIPT,
-                List.of(redisKey),
-                String.valueOf(VIEW_WINDOW.toSeconds())
-        );
+        Long currentCount = redisCounterSupport.incrementWithTtl(redisKey, VIEW_WINDOW);
 
         return currentCount != null && currentCount <= VIEW_LIMIT_PER_HOUR;
     }
@@ -38,19 +31,5 @@ public class RedisDocumentViewLimiter {
         }
 
         return VIEW_LIMIT_KEY_PREFIX + ":document:" + documentId + ":ip:" + viewerIp;
-    }
-
-    // TTL 포함 증가 Lua 스크립트 생성 메서드
-    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        script.setScriptText("""
-                local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
-                    redis.call('EXPIRE', KEYS[1], ARGV[1])
-                end
-                return current
-                """);
-        return script;
     }
 }

--- a/src/main/java/com/jinju/jinjuwiki/global/config/RedisCounterSupport.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/RedisCounterSupport.java
@@ -37,7 +37,7 @@ public class RedisCounterSupport {
         script.setResultType(Long.class);
         script.setScriptText("""
                 local current = redis.call('INCR', KEYS[1])
-                if current == 1 then
+                if current == 1 or redis.call('TTL', KEYS[1]) == -1 then
                     redis.call('EXPIRE', KEYS[1], ARGV[1])
                 end
                 return current

--- a/src/main/java/com/jinju/jinjuwiki/global/config/RedisCounterSupport.java
+++ b/src/main/java/com/jinju/jinjuwiki/global/config/RedisCounterSupport.java
@@ -1,0 +1,47 @@
+package com.jinju.jinjuwiki.global.config;
+
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+// Redis 카운터 증감/TTL 공통 처리 컴포넌트
+@Component
+@RequiredArgsConstructor
+public class RedisCounterSupport {
+
+    private static final DefaultRedisScript<Long> INCREMENT_WITH_TTL_SCRIPT = createIncrementWithTtlScript();
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public Long incrementWithTtl(String key, Duration ttl) {
+        return stringRedisTemplate.execute(
+                INCREMENT_WITH_TTL_SCRIPT,
+                List.of(key),
+                String.valueOf(ttl.toSeconds())
+        );
+    }
+
+    public String get(String key) {
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        stringRedisTemplate.delete(key);
+    }
+
+    private static DefaultRedisScript<Long> createIncrementWithTtlScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setResultType(Long.class);
+        script.setScriptText("""
+                local current = redis.call('INCR', KEYS[1])
+                if current == 1 then
+                    redis.call('EXPIRE', KEYS[1], ARGV[1])
+                end
+                return current
+                """);
+        return script;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Redis 연산 공통화 수준으로만 처리
- 각 limiter의 도메인별 공개 메서드와 예외 정책은 유지하고, 중복되던 `INCR + EXPIRE Lua 실행 로직`만 공통 helper로 추출

## 변경 이유
- 

## 관련 이슈
- #108 

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
