### PR TITLE
refactor : 통합 테스트 전용 설정 프로파일 분리

### DIFF
--- a/src/test/java/com/jinju/jinjuwiki/JinjuWikiApplicationTests.java
+++ b/src/test/java/com/jinju/jinjuwiki/JinjuWikiApplicationTests.java
@@ -2,9 +2,11 @@ package com.jinju.jinjuwiki;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 // 애플리케이션 컨텍스트 테스트 클래스
 @SpringBootTest
+@ActiveProfiles("integration")
 class JinjuWikiApplicationTests {
 
     @Test

--- a/src/test/java/com/jinju/jinjuwiki/domain/search/controller/SearchSecurityIntegrationTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/search/controller/SearchSecurityIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -22,6 +23,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 // 급상승 문서 보안 통합 테스트 클래스
 @SpringBootTest
+@ActiveProfiles("integration")
 class SearchSecurityIntegrationTest {
 
     @Autowired

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -13,8 +13,3 @@ spring:
   mail:
     host: localhost
     port: 2525
-
-app:
-  upload:
-    image-path: /tmp/jinjuwiki-test-uploads/images
-    image-url-prefix: /uploads/images/

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:jinjuwiki;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  flyway:
+    enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+  mail:
+    host: localhost
+    port: 2525
+
+app:
+  upload:
+    image-path: /tmp/jinjuwiki-test-uploads/images
+    image-url-prefix: /uploads/images/

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,19 +1,3 @@
-spring:
-  datasource:
-    url: jdbc:h2:mem:jinjuwiki;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  flyway:
-    enabled: false
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    open-in-view: false
-  mail:
-    host: localhost
-    port: 2525
-
 jwt:
   secret: jinjuwiki-jwt-secret-key-for-test-environment-2026
   access-token-expiration: 3600000


### PR DESCRIPTION
## 작업 내용
- 테스트 전역 공통값만 남김
- `datasource, flyway, jpa, mail` 같은 통합 테스트 기동 설정을 분리

## 변경 이유
- 

## 관련 이슈
- #106 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
