### PR TITLE
refactor : document content_json 컬럼을 jsonb로 전환

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +43,7 @@ public class Document extends BaseEntity {
     @Column
     private Integer eventYear;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     private String contentJson;
 

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
@@ -41,7 +41,7 @@ public class Document extends BaseEntity {
     @Column
     private Integer eventYear;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "jsonb")
     private String contentJson;
 
     @Builder.Default

--- a/src/main/resources/db/migration/V4__change_document_content_json_to_jsonb.sql
+++ b/src/main/resources/db/migration/V4__change_document_content_json_to_jsonb.sql
@@ -1,3 +1,25 @@
 alter table document
     alter column content_json type jsonb
-    using content_json::jsonb;
+    using (
+        case
+            when content_json is null or btrim(content_json) = '' then
+                jsonb_build_object('type', 'doc', 'content', jsonb_build_array())
+            when btrim(content_json) like '{%' or btrim(content_json) like '[%' then
+                content_json::jsonb
+            else
+                jsonb_build_object(
+                    'type', 'doc',
+                    'content', jsonb_build_array(
+                        jsonb_build_object(
+                            'type', 'paragraph',
+                            'content', jsonb_build_array(
+                                jsonb_build_object(
+                                    'type', 'text',
+                                    'text', content_json
+                                )
+                            )
+                        )
+                    )
+                )
+        end
+    );

--- a/src/main/resources/db/migration/V4__change_document_content_json_to_jsonb.sql
+++ b/src/main/resources/db/migration/V4__change_document_content_json_to_jsonb.sql
@@ -1,0 +1,3 @@
+alter table document
+    alter column content_json type jsonb
+    using content_json::jsonb;


### PR DESCRIPTION
## 작업 내용
- `document.content_json` 컬럼 타입을 jsonb로 전환하는 새 migration을 추가했고, 엔티티 매핑도 jsonb 기준으로 정립

## 변경 이유
- 

## 관련 이슈
- Closes #103 

## 테스트
- [x] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [ ] 리뷰 포인트를 정리했다
