### PR TITLE
fix : 문서 목록 및 검색 조회의 N+1 쿼리 제거

### DIFF
--- a/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/entity/Document.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import lombok.AccessLevel;
@@ -22,10 +24,20 @@ import lombok.NoArgsConstructor;
 // JPA 표준 패턴 기반 문서 Entity 클래스
 @Getter
 @Entity
+@NamedEntityGraph(
+        name = Document.DOCUMENT_WITH_RELATIONS_GRAPH,
+        attributeNodes = {
+                @NamedAttributeNode("author"),
+                @NamedAttributeNode("category"),
+                @NamedAttributeNode("schoolDocument")
+        }
+)
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Document extends BaseEntity {
+
+    public static final String DOCUMENT_WITH_RELATIONS_GRAPH = "Document.withRelations";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -2,6 +2,8 @@ package com.jinju.jinjuwiki.domain.document.repository;
 
 import com.jinju.jinjuwiki.domain.document.entity.Document;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,12 +15,20 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
+    @Override
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    Optional<Document> findById(Long id);
+
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     Page<Document> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     Page<Document> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     Page<Document> findBySchoolDocumentIdOrderByCreatedAtDesc(Long schoolDocumentId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     Page<Document> findByCategoryIdAndSchoolDocumentIdOrderByCreatedAtDesc(Long categoryId, Long schoolDocumentId, Pageable pageable);
 
     List<Document> findByCategoryIdOrderByTitleAsc(Long categoryId);
@@ -44,6 +54,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     int incrementViewCountBy(@Param("documentId") Long documentId, @Param("delta") long delta);
 
     // concat() : 두개 이상의 컬럼이나 문자열을 순서대로 묶어 하나의 문자열로 반환
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     @Query("""
             select d
             from Document d
@@ -56,6 +67,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     @Query("""
             select d
             from Document d
@@ -72,6 +84,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     @Query("""
             select d
             from Document d
@@ -88,6 +101,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
+    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
     @Query("""
             select d
             from Document d

--- a/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepository.java
@@ -16,19 +16,19 @@ import org.springframework.stereotype.Repository;
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
     @Override
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     Optional<Document> findById(Long id);
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     Page<Document> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     Page<Document> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     Page<Document> findBySchoolDocumentIdOrderByCreatedAtDesc(Long schoolDocumentId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     Page<Document> findByCategoryIdAndSchoolDocumentIdOrderByCreatedAtDesc(Long categoryId, Long schoolDocumentId, Pageable pageable);
 
     List<Document> findByCategoryIdOrderByTitleAsc(Long categoryId);
@@ -54,7 +54,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     int incrementViewCountBy(@Param("documentId") Long documentId, @Param("delta") long delta);
 
     // concat() : 두개 이상의 컬럼이나 문자열을 순서대로 묶어 하나의 문자열로 반환
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     @Query("""
             select d
             from Document d
@@ -67,7 +67,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     @Query("""
             select d
             from Document d
@@ -84,7 +84,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     @Query("""
             select d
             from Document d
@@ -101,7 +101,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
             Pageable pageable
     );
 
-    @EntityGraph(attributePaths = {"author", "category", "schoolDocument"})
+    @EntityGraph(value = Document.DOCUMENT_WITH_RELATIONS_GRAPH)
     @Query("""
             select d
             from Document d

--- a/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
@@ -12,11 +12,14 @@ import com.jinju.jinjuwiki.domain.user.entity.UserRole;
 import com.jinju.jinjuwiki.domain.user.repository.UserRepository;
 import com.jinju.jinjuwiki.global.config.JpaAuditingConfig;
 import jakarta.persistence.EntityManager;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 // 문서 저장소 원자 증가 쿼리 테스트 클래스
 @DataJpaTest
@@ -79,20 +82,92 @@ class DocumentRepositoryTest {
         assertThat(reloadedDocument.getViewCount()).isEqualTo(5L);
     }
 
+    @Test
+    @DisplayName("문서 단건 조회는 응답 조립에 필요한 연관 엔티티를 함께 로드한다.")
+    void findByIdLoadsRequiredAssociations() {
+        User author = userRepository.save(createUser("detail@test.com", "detailUser"));
+        Category schoolCategory = categoryRepository.save(createCategory("학교"));
+        Category childCategory = categoryRepository.save(createCategory("학생"));
+        Document schoolDocument = documentRepository.saveAndFlush(createDocument("진주고등학교", author, schoolCategory, null));
+        Document savedDocument = documentRepository.saveAndFlush(createDocument("학생 문서", author, childCategory, schoolDocument));
+
+        entityManager.clear();
+
+        Document foundDocument = documentRepository.findById(savedDocument.getId()).orElseThrow();
+
+        assertThat(Hibernate.isInitialized(foundDocument.getAuthor())).isTrue();
+        assertThat(Hibernate.isInitialized(foundDocument.getCategory())).isTrue();
+        assertThat(Hibernate.isInitialized(foundDocument.getSchoolDocument())).isTrue();
+    }
+
+    @Test
+    @DisplayName("문서 목록 조회는 DTO 매핑에 필요한 연관 엔티티를 함께 로드한다.")
+    void findByCategoryIdOrderByCreatedAtDescLoadsRequiredAssociations() {
+        User author = userRepository.save(createUser("list@test.com", "listUser"));
+        Category schoolCategory = categoryRepository.save(createCategory("학교"));
+        Category childCategory = categoryRepository.save(createCategory("학생"));
+        Document schoolDocument = documentRepository.saveAndFlush(createDocument("진주여고", author, schoolCategory, null));
+        documentRepository.saveAndFlush(createDocument("학생 문서 1", author, childCategory, schoolDocument));
+        documentRepository.saveAndFlush(createDocument("학생 문서 2", author, childCategory, schoolDocument));
+
+        entityManager.clear();
+
+        Page<Document> documents = documentRepository.findByCategoryIdOrderByCreatedAtDesc(
+                childCategory.getId(),
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(documents.getContent()).hasSize(2);
+        assertThat(documents.getContent())
+                .allSatisfy(document -> {
+                    assertThat(Hibernate.isInitialized(document.getAuthor())).isTrue();
+                    assertThat(Hibernate.isInitialized(document.getCategory())).isTrue();
+                    assertThat(Hibernate.isInitialized(document.getSchoolDocument())).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("문서 검색 조회는 DTO 매핑에 필요한 연관 엔티티를 함께 로드한다.")
+    void searchByKeywordLoadsRequiredAssociations() {
+        User author = userRepository.save(createUser("search@test.com", "searchUser"));
+        Category schoolCategory = categoryRepository.save(createCategory("학교"));
+        Category childCategory = categoryRepository.save(createCategory("사건사고"));
+        Document schoolDocument = documentRepository.saveAndFlush(createDocument("진주중앙고", author, schoolCategory, null));
+        documentRepository.saveAndFlush(createDocument("축제 사고 문서", author, childCategory, schoolDocument));
+
+        entityManager.clear();
+
+        Page<Document> documents = documentRepository.searchByKeyword("사고", PageRequest.of(0, 10));
+
+        assertThat(documents.getContent()).hasSize(1);
+        Document foundDocument = documents.getContent().getFirst();
+        assertThat(Hibernate.isInitialized(foundDocument.getAuthor())).isTrue();
+        assertThat(Hibernate.isInitialized(foundDocument.getCategory())).isTrue();
+        assertThat(Hibernate.isInitialized(foundDocument.getSchoolDocument())).isTrue();
+    }
+
     // 테스트용 사용자 생성 메서드
     private User createUser() {
+        return createUser("view-count@test.com", "viewCounter");
+    }
+
+    private User createUser(String email, String nickname) {
         return User.builder()
-                .email("view-count@test.com")
+                .email(email)
                 .password("encoded-password")
-                .nickname("viewCounter")
+                .nickname(nickname)
                 .role(UserRole.USER)
                 .build();
     }
 
     // 테스트용 카테고리 생성 메서드
     private Category createCategory() {
+        return createCategory("조회수");
+    }
+
+    private Category createCategory(String name) {
         return Category.builder()
-                .name("조회수")
+                .name(name)
                 .build();
     }
 
@@ -132,18 +207,23 @@ class DocumentRepositoryTest {
 
     // delta 테스트용 문서 생성 메서드
     private Document createDeltaDocument(User author, Category category) {
+        return createDocument("조회수 delta 테스트 문서", author, category, null);
+    }
+
+    private Document createDocument(String title, User author, Category category, Document schoolDocument) {
         ObjectNode contentJson = OBJECT_MAPPER.createObjectNode();
         contentJson.put("type", "doc");
         contentJson.putArray("content");
 
         return Document.builder()
-                .title("조회수 delta 테스트 문서")
+                .title(title)
                 .content(contentJson.toString())
                 .summary("조회수 delta 테스트 요약")
                 .eventYear(2026)
                 .contentJson(contentJson.toString())
                 .author(author)
                 .category(category)
+                .schoolDocument(schoolDocument)
                 .build();
     }
 }


### PR DESCRIPTION
## 작업 내용
- 목록 1건당 `author/category/schoolDocument` 추가 select가 붙던 구조를 조회 시점의 join fetch 성격으로 정리
- 상세 조회와 수정/삭제 진입점의 findById도 같은 방식으로 정리해서 단건 응답 조립 시 불필요한 지연 로딩 완화

## 변경 이유
- 성능 개선

## 관련 이슈
- 

## 테스트
- [x] `./gradlew test`
- [x] 수동 확인

## 스크린샷
- 

## 체크리스트
- [ ] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
