### PR TITLE
fix : DocumentRepositoryTest H2 JSONB 설정 수정

### DIFF
--- a/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
+++ b/src/test/java/com/jinju/jinjuwiki/domain/document/repository/DocumentRepositoryTest.java
@@ -17,12 +17,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
 
 // 문서 저장소 원자 증가 쿼리 테스트 클래스
 @DataJpaTest
+@ActiveProfiles("integration")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaAuditingConfig.class)
 class DocumentRepositoryTest {
 

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:jinjuwiki;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:jinjuwiki;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=CREATE DOMAIN IF NOT EXISTS JSONB AS JSON
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
## 작업 내용
- `DocumentRepositoryTest`가 `integration` 테스트 datasource를 사용하도록 설정
- H2 테스트 datasource에 `JSONB` domain alias 추가

## 변경 이유
- `Document.contentJson`의 `jsonb` 컬럼 정의가 H2 DDL 생성 시 `Unknown data type: "JSONB"` 오류를 발생시킴
- 이로 인해 `document` 테이블 생성이 실패하고 `DocumentRepositoryTest`가 `Table "DOCUMENT" not found`로 연쇄 실패함

## 관련 이슈
- Closes #117

## 테스트
- [x] `./gradlew test --tests com.jinju.jinjuwiki.domain.document.repository.DocumentRepositoryTest`
- [x] `./gradlew test --tests com.jinju.jinjuwiki.JinjuWikiApplicationTests`
- [ ] `./gradlew test`
- [ ] 수동 확인

## 스크린샷
- 해당 없음

## 체크리스트
- [x] 관련 이슈를 연결했다
- [x] 불필요한 디버그 코드와 로그를 제거했다
- [x] 리뷰 포인트를 정리했다
